### PR TITLE
Moved created patient birth dates back to fix visit date conflict exception.

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencedemodata/ReferenceDemoDataActivator.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/ReferenceDemoDataActivator.java
@@ -110,7 +110,7 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
         createSchedulerUserAndGPs();
         createAppointmentTypes();
         createDemoPatients();
-        
+
         cachedConcepts.clear();
 	}
 	
@@ -595,7 +595,7 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
 		return new Obs(patient, concept, encounterTime, location);
 	}
 	
-	private static final int MIN_AGE = 2;
+	private static final int MIN_AGE = 4;
 	private static final int MAX_AGE = 90;
 	
 	private Date randomBirthdate() {


### PR DESCRIPTION
When I was trying to create a few hundred demo patients, it always failed at some point in the process with this error:
`failed to validate with reason: startDatetime: Visit.startDateCannotFallBeforeTheBirthDateOfTheSamePatient`
with the relevant part of the stack trace being:
`at org.openmrs.module.referencedemodata.ReferenceDemoDataActivator.createDemoPatient(ReferenceDemoDataActivator.java:398)`
`at org.openmrs.module.referencedemodata.ReferenceDemoDataActivator.createDemoPatients(ReferenceDemoDataActivator.java:365)`
`at org.openmrs.module.referencedemodata.ReferenceDemoDataActivator.started(ReferenceDemoDataActivator.java:112)`
Inspecting the logic, it seems the root cause is that the birth date of the created patient can be less than a year old while the visit date can go as far as two years ago.
Tested the change in a live server (since unit-test framework for mocking the random number generator is not implemented before) and it succeeded creating hundreds of patients. 