### PR TITLE
Ensure visits have enough time to contain encounters

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencedemodata/patient/DemoPatientGenerator.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/patient/DemoPatientGenerator.java
@@ -246,7 +246,11 @@ public class DemoPatientGenerator {
 					}
 				}
 			} else {
-				visitStart = LocalDateTime.now();
+				// all new/"non-retrospective" visits should happen 90 minutes before the current time, this is 
+				// because some associated encounters happen anywhere from 0 to 60 minutes after the visit, this
+				// is done to avoid encounter validation errors
+				// (see https://github.com/openmrs/openmrs-core/blob/b7c03a28c64493023a8211c53bb60d4d944b39b7/api/src/main/java/org/openmrs/validator/EncounterValidator.java#L89)
+				visitStart = LocalDateTime.now().minusMinutes(90);
 			}
 		} else {
 			visitStart = toLocalDateTime(lastVisit.getStopDatetime())


### PR DESCRIPTION
This PR ensures all new/"non-retrospective" visits happen 90 minutes before the current time, this is because some associated encounters happen anywhere from 0 to 60 minutes after the visit is started, resulting in successful encounter validations without errors.
see https://github.com/openmrs/openmrs-core/blob/b7c03a28c64493023a8211c53bb60d4d944b39b7/api/src/main/java/org/openmrs/validator/EncounterValidator.java#L89)