### PR TITLE
feat: reproducible & curated demo patients

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,15 @@
                 </includes>
                 <filtering>false</filtering>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*.yaml</include>
+                    <include>**/*.yml</include>
+                    <include>**/*.txt</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
 		</resources>
 
 		<testResources>
@@ -37,5 +46,13 @@
 			</testResource>
 		</testResources>
 	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>2.3</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/api/src/main/java/org/openmrs/module/referencedemodata/DemoDataContext.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/DemoDataContext.java
@@ -1,0 +1,106 @@
+package org.openmrs.module.referencedemodata;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.openmrs.api.AdministrationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds all sources of non-determinism behind one object. Thread one of these
+ * through every generation path so seed + clock anchor fully determine the output.
+ *
+ * Single-threaded by design. If any caller ever parallelizes generation, it MUST
+ * use {@link java.util.SplittableRandom#split()} at a known point — do not share
+ * the same instance across threads.
+ */
+public final class DemoDataContext {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoDataContext.class);
+
+    public static final String GP_SEED = "referencedemodata.seed";
+    public static final String GP_CLOCK_ANCHOR = "referencedemodata.clockAnchor";
+    public static final Instant DEFAULT_CLOCK_ANCHOR = Instant.parse("2025-01-01T00:00:00Z");
+    public static final long DEFAULT_SEED = 0L;
+
+    private final long seed;
+    private final Instant clockAnchor;
+    private final java.util.SplittableRandom random;
+    private long uuidCounter = 0L;
+    private long identifierCounter = 0L;
+
+    public static final ZoneId ZONE = ZoneId.of("UTC");
+    public static final Locale LOCALE = Locale.ROOT;
+
+    private DemoDataContext(long seed, Instant clockAnchor) {
+        this.seed = seed;
+        this.clockAnchor = clockAnchor;
+        this.random = new java.util.SplittableRandom(seed);
+    }
+
+    public static DemoDataContext of(long seed, Instant clockAnchor) {
+        return new DemoDataContext(seed, clockAnchor);
+    }
+
+    public static DemoDataContext fromGlobalProperties(AdministrationService svc) {
+        long seed = parseLong(svc.getGlobalProperty(GP_SEED, Long.toString(DEFAULT_SEED)), DEFAULT_SEED);
+        Instant anchor;
+        String raw = svc.getGlobalProperty(GP_CLOCK_ANCHOR, DEFAULT_CLOCK_ANCHOR.toString());
+        try {
+            anchor = Instant.parse(raw);
+        } catch (DateTimeParseException e) {
+            log.warn("Could not parse GP " + GP_CLOCK_ANCHOR + "=" + raw + " as Instant; falling back to " + DEFAULT_CLOCK_ANCHOR);
+            anchor = DEFAULT_CLOCK_ANCHOR;
+        }
+        return new DemoDataContext(seed, anchor);
+    }
+
+    private static long parseLong(String s, long fallback) {
+        try {
+            return Long.parseLong(s);
+        } catch (NumberFormatException e) {
+            log.warn("Could not parse '" + s + "' as long; falling back to " + fallback);
+            return fallback;
+        }
+    }
+
+    public long seed() { return seed; }
+    public Instant clockAnchor() { return clockAnchor; }
+    public java.util.SplittableRandom random() { return random; }
+
+    /**
+     * Deterministically picks one element from any collection by sorting it via
+     * the supplied key extractor first. Defends against HashMap iteration order.
+     */
+    public <T, K extends Comparable<K>> T pick(Collection<T> items, Function<T, K> key) {
+        if (items.isEmpty()) throw new IllegalArgumentException("empty collection");
+        List<T> sorted = items.stream()
+                .sorted(Comparator.comparing(key))
+                .collect(Collectors.toList());
+        return sorted.get(random.nextInt(sorted.size()));
+    }
+
+    /** Deterministic UUIDv4 derived from (seed, monotonically-increasing counter). */
+    public UUID newUuid() {
+        long n = uuidCounter++;
+        ByteBuffer bb = ByteBuffer.allocate(16);
+        bb.putLong(seed).putLong(n);
+        byte[] bytes = bb.array();
+        bytes[6] &= 0x0f; bytes[6] |= 0x40; // version 4
+        bytes[8] &= 0x3f; bytes[8] |= 0x80; // variant
+        ByteBuffer b2 = ByteBuffer.wrap(bytes);
+        return new UUID(b2.getLong(), b2.getLong());
+    }
+
+    /** Monotonically-increasing identifier counter for DEMO-NNNNNNNNNN identifiers. */
+    public long nextIdentifierIndex() { return identifierCounter++; }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/DemoIdentifiers.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/DemoIdentifiers.java
@@ -1,0 +1,42 @@
+package org.openmrs.module.referencedemodata;
+
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.idgen.service.IdentifierSourceService;
+import org.openmrs.module.referencemetadata.ReferenceMetadataConstants;
+
+/** Thin adapter for generating OpenMRS IDs via idgen's "DemoData" source. */
+public final class DemoIdentifiers {
+    private DemoIdentifiers() {}
+
+    private static IdentifierSourceService issOverride;
+
+    /** Test hook for injecting a mock IdentifierSourceService. */
+    public static void setIdentifierSourceService(IdentifierSourceService iss) {
+        issOverride = iss;
+    }
+
+    private static IdentifierSourceService iss() {
+        if (issOverride != null) return issOverride;
+        IdentifierSourceService iss = Context.getService(IdentifierSourceService.class);
+        if (iss == null) {
+            throw new IllegalStateException(
+                    "IdentifierSourceService unavailable — is the idgen module loaded and started?");
+        }
+        return iss;
+    }
+
+    public static PatientIdentifierType type() {
+        PatientIdentifierType t = Context.getPatientService()
+                .getPatientIdentifierTypeByName(ReferenceMetadataConstants.OPENMRS_ID_NAME);
+        if (t == null) {
+            throw new IllegalStateException(
+                    "OpenMRS ID PatientIdentifierType is missing — has the referencemetadata module started?");
+        }
+        return t;
+    }
+
+    public static String next() {
+        return iss().generateIdentifier(type(), ReferenceDemoDataConstants.DEMO_IDGEN_SOURCE_NAME);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/DemoProvider.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/DemoProvider.java
@@ -1,0 +1,36 @@
+package org.openmrs.module.referencedemodata;
+
+import java.util.Date;
+import org.openmrs.Person;
+import org.openmrs.PersonName;
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+
+public final class DemoProvider {
+    private DemoProvider() {}
+
+    public static Provider ensure() {
+        Provider existing = Context.getProviderService()
+                .getProviderByUuid(ReferenceDemoDataConstants.DEMO_PROVIDER_UUID);
+        if (existing != null) return existing;
+
+        Person person = Context.getPersonService()
+                .getPersonByUuid(ReferenceDemoDataConstants.DEMO_PROVIDER_PERSON_UUID);
+        if (person == null) {
+            person = new Person();
+            person.setUuid(ReferenceDemoDataConstants.DEMO_PROVIDER_PERSON_UUID);
+            person.setGender("U");
+            PersonName name = new PersonName("Demo", null, "Provider");
+            person.addName(name);
+            person.setBirthdate(Date.from(java.time.LocalDate.of(1970, 1, 1)
+                    .atStartOfDay(java.time.ZoneOffset.UTC).toInstant()));
+            Context.getPersonService().savePerson(person);
+        }
+
+        Provider p = new Provider();
+        p.setUuid(ReferenceDemoDataConstants.DEMO_PROVIDER_UUID);
+        p.setPerson(person);
+        p.setIdentifier("DEMO-PROVIDER");
+        return Context.getProviderService().saveProvider(p);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/RandomPatientGenerator.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/RandomPatientGenerator.java
@@ -1,0 +1,424 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.referencedemodata;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Concept;
+import org.openmrs.ConceptNumeric;
+import org.openmrs.Encounter;
+import org.openmrs.Form;
+import org.openmrs.Location;
+import org.openmrs.Obs;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.PersonAddress;
+import org.openmrs.PersonName;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.FormService;
+import org.openmrs.api.ObsService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.VisitService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.emrapi.EmrApiConstants;
+import org.openmrs.util.OpenmrsConstants;
+
+/**
+ * Random patient generation extracted from {@link ReferenceDemoDataActivator}.
+ *
+ * <p>All sources of non-determinism (random numbers, clock reads) are routed
+ * through the supplied {@link DemoDataContext}, so the same (seed, clockAnchor)
+ * produces byte-identical output.
+ */
+public class RandomPatientGenerator {
+
+    private final Log log = LogFactory.getLog(getClass());
+
+    private static final int ADMISSION_DAYS_MIN = 1;
+    private static final int ADMISSION_DAYS_MAX = 3;
+    private static final int MIN_AGE = 2;
+    private static final int MAX_AGE = 90;
+
+    // Stable key extractors for ctx.pick — UUIDs are assigned by the MDS metadata and
+    // are stable across runs regardless of locale / session state / DB insertion order.
+    private static final java.util.function.Function<VisitType, String> VISIT_TYPE_UUID =
+            new java.util.function.Function<VisitType, String>() {
+                @Override public String apply(VisitType v) { return v.getUuid(); }
+            };
+    private static final java.util.function.Function<Concept, String> CONCEPT_UUID =
+            new java.util.function.Function<Concept, String>() {
+                @Override public String apply(Concept c) { return c.getUuid(); }
+            };
+
+    private final Map<String, Concept> cachedConcepts = new WeakHashMap<String, Concept>();
+
+    /**
+     * Creates {@code count} random patients, threading {@code ctx} through all
+     * random/time calls.
+     */
+    public void generate(DemoDataContext ctx, int count) {
+        if (count <= 0) {
+            return;
+        }
+
+        createVitalsForm();
+
+        PatientService ps = Context.getPatientService();
+        Location rootLocation = ctx.pick(Context.getLocationService().getRootLocations(false), Location::getUuid);
+        PatientIdentifierType patientIdentifierType = DemoIdentifiers.type();
+
+        for (int i = 0; i < count; i++) {
+            Patient patient = createDemoPatient(ctx, ps, patientIdentifierType, rootLocation);
+            log.info("created demo patient: " + patient.getPatientIdentifier()
+                    + " " + patient.getGivenName() + " " + patient.getFamilyName());
+            Context.flushSession();
+            Context.clearSession();
+        }
+    }
+
+    private void createVitalsForm() {
+        FormService fs = Context.getFormService();
+        if (fs.getFormByUuid(ReferenceDemoDataConstants.VITALS_FORM_UUID) != null) {
+            return;
+        }
+        Form form = new Form();
+        form.setUuid(ReferenceDemoDataConstants.VITALS_FORM_UUID);
+        form.setName(ReferenceDemoDataConstants.VITALS_FORM_NAME);
+        form.setEncounterType(Context.getEncounterService().getEncounterTypeByUuid(
+                ReferenceDemoDataConstants.VITALS_FORM_ENCOUNTERTYPE_UUID));
+        form.setVersion("1.0");
+        fs.saveForm(form);
+    }
+
+    private Patient createDemoPatient(DemoDataContext ctx, PatientService ps,
+                                      PatientIdentifierType patientIdentifierType, Location location) {
+        Patient patient = createBasicDemoPatient(ctx, patientIdentifierType, location);
+        patient = ps.savePatient(patient);
+        VisitService vs = Context.getVisitService();
+        int visitCount = randomBetween(ctx, 0, 10);
+        for (int i = 0; i < visitCount; i++) {
+            boolean shortVisit = i < (visitCount * 0.75);
+            Visit visit = createDemoVisit(ctx, patient, vs.getAllVisitTypes(), location, shortVisit);
+            vs.saveVisit(visit);
+        }
+        return patient;
+    }
+
+    private Patient createBasicDemoPatient(DemoDataContext ctx, PatientIdentifierType patientIdentifierType,
+                                           Location location) {
+        Patient patient = new Patient();
+
+        PersonName pName = new PersonName();
+        String gender = randomArrayEntry(ctx, GENDERS);
+        boolean male = gender.equals("M");
+        pName.setGivenName(randomArrayEntry(ctx, male ? MALE_FIRST_NAMES : FEMALE_FIRST_NAMES));
+        pName.setFamilyName(randomArrayEntry(ctx, FAMILY_NAMES));
+        patient.addName(pName);
+
+        PersonAddress pAddress = new PersonAddress();
+        String randomSuffix = randomSuffix(ctx);
+        pAddress.setAddress1("Address1" + randomSuffix);
+        pAddress.setCityVillage("City" + randomSuffix);
+        pAddress.setStateProvince("State" + randomSuffix);
+        pAddress.setCountry("Country" + randomSuffix);
+        pAddress.setPostalCode(randomSuffix(ctx, 5));
+        patient.addAddress(pAddress);
+
+        patient.setBirthdate(randomBirthdate(ctx));
+        patient.setBirthdateEstimated(false);
+        patient.setGender(gender);
+
+        PatientIdentifier pa1 = new PatientIdentifier();
+        pa1.setIdentifier(DemoIdentifiers.next());
+        pa1.setIdentifierType(patientIdentifierType);
+        pa1.setDateCreated(Date.from(ctx.clockAnchor()));
+        pa1.setLocation(location);
+        patient.addIdentifier(pa1);
+
+        return patient;
+    }
+
+    private Visit createDemoVisit(DemoDataContext ctx, Patient patient, List<VisitType> visitTypes,
+                                  Location location, boolean shortVisit) {
+        LocalDateTime anchor = LocalDateTime.ofInstant(ctx.clockAnchor(), ZoneId.of("UTC"));
+        LocalDateTime visitStart = anchor.minusDays(randomBetween(ctx, 0, 365 * 2)).minusHours(3); // past 2 years
+        if (!shortVisit) {
+            visitStart = visitStart.minusDays(ADMISSION_DAYS_MAX + 1);
+        }
+        // ctx.pick sorts by UUID before picking — DB list order varies with session state,
+        // which would otherwise desynchronise the seeded RNG.
+        Visit visit = new Visit(patient, ctx.pick(visitTypes, VISIT_TYPE_UUID), toDate(visitStart));
+        visit.setLocation(location);
+        LocalDateTime vitalsTime = visitStart.plusMinutes(randomBetween(ctx, 1, 60));
+        visit.addEncounter(createDemoVitalsEncounter(ctx, patient, toDate(vitalsTime)));
+        LocalDateTime visitNoteTime = visitStart.plusMinutes(randomBetween(ctx, 60, 120));
+        visit.addEncounter(createVisitNote(ctx, patient, toDate(visitNoteTime), location));
+        if (shortVisit) {
+            LocalDateTime visitEndTime = visitNoteTime.plusMinutes(30);
+            visit.setStopDatetime(toDate(visitEndTime));
+        } else {
+            Location admitLocation = Context.getLocationService().getLocation("Inpatient Ward");
+            visit.addEncounter(createEncounter("Admission", patient, toDate(visitNoteTime), admitLocation));
+            LocalDateTime dischargeDateTime = visitNoteTime.plusDays(
+                    randomBetween(ctx, ADMISSION_DAYS_MIN, ADMISSION_DAYS_MAX));
+            visit.addEncounter(createEncounter("Discharge", patient, toDate(dischargeDateTime), admitLocation));
+            visit.setStopDatetime(toDate(dischargeDateTime));
+        }
+        return visit;
+    }
+
+    private static Date toDate(LocalDateTime ldt) {
+        return Date.from(ldt.atZone(ZoneId.of("UTC")).toInstant());
+    }
+
+    private Encounter createVisitNote(DemoDataContext ctx, Patient patient, Date encounterTime, Location location) {
+        ObsService os = Context.getObsService();
+        ConceptService cs = Context.getConceptService();
+        Encounter visitNote = createEncounter("Visit Note", patient, encounterTime, location);
+        visitNote.setForm(Context.getFormService().getForm("Visit Note"));
+        Context.getEncounterService().saveEncounter(visitNote);
+
+        createTextObs("Text of encounter note"/*CIEL:162169*/, randomArrayEntry(ctx, RANDOM_TEXT),
+                patient, visitNote, encounterTime, location, os, cs);
+
+        createDiagnosisObsGroup(ctx, true, patient, visitNote, encounterTime, location, os, cs);
+
+        if (flipACoin(ctx)) {
+            createDiagnosisObsGroup(ctx, false, patient, visitNote, encounterTime, location, os, cs);
+        }
+
+        return visitNote;
+    }
+
+    private void createDiagnosisObsGroup(DemoDataContext ctx, boolean primary, Patient patient, Encounter visitNote,
+                                         Date encounterTime, Location location, ObsService os, ConceptService cs) {
+        Obs obsGroup = createBasicObs("Visit Diagnoses", patient, encounterTime, location, cs);
+        visitNote.addObs(obsGroup);
+
+        boolean valueBefore = Context.getAdministrationService().isDatabaseStringComparisonCaseSensitive();
+        Context.getAdministrationService().setGlobalProperty(
+                OpenmrsConstants.GP_CASE_SENSITIVE_DATABASE_STRING_COMPARISON, "true");
+
+        String certainty = flipACoin(ctx) ? "Presumed diagnosis" : "Confirmed diagnosis";
+        Obs obs1 = createCodedObs(EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_CERTAINTY, certainty,
+                patient, visitNote, encounterTime, location, os, cs);
+
+        // TODO 5% of diagnoses should be non-coded.
+        // ctx.pick sorts by UUID so DB-returned list order (which is locale- and session-
+        // sensitive via getConceptsByClass) can't drift the seeded RNG between runs.
+        List<Concept> allDiagnoses = cs.getConceptsByClass(cs.getConceptClassByName("Diagnosis"));
+        Obs obs2 = createCodedObs("DIAGNOSIS LIST", ctx.pick(allDiagnoses, CONCEPT_UUID),
+                patient, visitNote, encounterTime, location, os, cs);
+
+        String order = primary
+                ? EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER_PRIMARY
+                : EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER_SECONDARY;
+        Obs obs3 = createCodedObs(EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER, order,
+                patient, visitNote, encounterTime, location, os, cs);
+
+        obsGroup.addGroupMember(obs1);
+        obsGroup.addGroupMember(obs2);
+        obsGroup.addGroupMember(obs3);
+        os.saveObs(obsGroup, "testing");
+
+        Context.getAdministrationService().setGlobalProperty(
+                OpenmrsConstants.GP_CASE_SENSITIVE_DATABASE_STRING_COMPARISON, String.valueOf(valueBefore));
+    }
+
+    private Encounter createDemoVitalsEncounter(DemoDataContext ctx, Patient patient, Date encounterTime) {
+        Location location = Context.getLocationService().getLocation("Outpatient Clinic");
+        Encounter encounter = createEncounter("Vitals", patient, encounterTime, location);
+        encounter.setForm(Context.getFormService().getForm("Vitals"));
+        createDemoVitalsObs(ctx, patient, encounter, encounterTime, location);
+        return encounter;
+    }
+
+    private Encounter createEncounter(String encounterType, Patient patient, Date encounterTime, Location location) {
+        EncounterService es = Context.getEncounterService();
+        Encounter encounter = new Encounter();
+        encounter.setEncounterDatetime(encounterTime);
+        encounter.setEncounterType(es.getEncounterType(encounterType));
+        encounter.setPatient(patient);
+        encounter.setLocation(location);
+        es.saveEncounter(encounter);
+        return encounter;
+    }
+
+    private void createDemoVitalsObs(DemoDataContext ctx, Patient patient, Encounter encounter,
+                                     Date encounterTime, Location location) {
+        ObsService os = Context.getObsService();
+        ConceptService cs = Context.getConceptService();
+        createNumericObs(ctx, "Height (cm)", 10, 228, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Weight (kg)", 1, 250, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Temperature (C)", 25, 43, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Pulse", 0, 230, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Respiratory rate", 5, 100, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Systolic blood pressure", 0, 250, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Diastolic blood pressure", 0, 150, patient, encounter, encounterTime, location, os, cs);
+        createNumericObs(ctx, "Blood oxygen saturation", 0, 100, patient, encounter, encounterTime, location, os, cs);
+    }
+
+    private void createNumericObs(DemoDataContext ctx, String conceptName, int min, int max, Patient patient,
+                                  Encounter encounter, Date encounterTime, Location location,
+                                  ObsService os, ConceptService cs) {
+        Obs obs = createBasicObs(conceptName, patient, encounterTime, location, cs);
+
+        Concept concept = obs.getConcept();
+        if (concept != null) {
+            ConceptNumeric conceptNumeric = cs.getConceptNumeric(concept.getConceptId());
+            if (conceptNumeric.getHiAbsolute() != null) {
+                max = conceptNumeric.getHiAbsolute().intValue();
+            }
+            if (conceptNumeric.getLowAbsolute() != null) {
+                min = conceptNumeric.getLowAbsolute().intValue();
+            }
+        }
+
+        obs.setValueNumeric((double) randomBetween(ctx, min, max));
+        encounter.addObs(obs);
+        os.saveObs(obs, null);
+    }
+
+    private void createTextObs(String conceptName, String text, Patient patient, Encounter encounter,
+                               Date encounterTime, Location location, ObsService os, ConceptService cs) {
+        Obs obs = createBasicObs(conceptName, patient, encounterTime, location, cs);
+        obs.setValueText(text);
+        encounter.addObs(obs);
+        os.saveObs(obs, null);
+    }
+
+    private Obs createCodedObs(String conceptName, String codedConceptName, Patient patient, Encounter encounter,
+                               Date encounterTime, Location location, ObsService os, ConceptService cs) {
+        return createCodedObs(conceptName, findConcept(codedConceptName, cs),
+                patient, encounter, encounterTime, location, os, cs);
+    }
+
+    private Concept findConcept(String conceptName, ConceptService cs) {
+        if (cachedConcepts.containsKey(conceptName)) {
+            return cachedConcepts.get(conceptName);
+        } else {
+            Concept concept = cs.getConcept(conceptName);
+            cachedConcepts.put(conceptName, concept);
+            return concept;
+        }
+    }
+
+    private Obs createCodedObs(String conceptName, Concept concept, Patient patient, Encounter encounter,
+                               Date encounterTime, Location location, ObsService os, ConceptService cs) {
+        Obs obs = createBasicObs(conceptName, patient, encounterTime, location, cs);
+        obs.setValueCoded(concept);
+        encounter.addObs(obs);
+        os.saveObs(obs, null);
+        return obs;
+    }
+
+    private Obs createBasicObs(String conceptName, Patient patient, Date encounterTime, Location location,
+                               ConceptService cs) {
+        Concept concept = findConcept(conceptName, cs);
+        if (concept == null) {
+            log.warn("incorrect concept name? " + conceptName);
+        }
+        return new Obs(patient, concept, encounterTime, location);
+    }
+
+    private Date randomBirthdate(DemoDataContext ctx) {
+        LocalDate now = ctx.clockAnchor().atZone(ZoneId.of("UTC")).toLocalDate();
+        int year = randomBetween(ctx, now.getYear() - MAX_AGE, now.getYear() - MIN_AGE);
+        int month = randomBetween(ctx, 1, 12);
+        int day = randomBetween(ctx, 1, 28);
+        LocalDate birth = LocalDate.of(year, month, day);
+        return Date.from(birth.atStartOfDay(ZoneId.of("UTC")).toInstant());
+    }
+
+    // ---- Random helpers routed through DemoDataContext ----
+
+    private static int randomBetween(DemoDataContext ctx, int min, int max) {
+        return min + (int) (ctx.random().nextDouble() * (max - min + 1));
+    }
+
+    private static int randomArrayIndex(DemoDataContext ctx, int length) {
+        return (int) (ctx.random().nextDouble() * length);
+    }
+
+    private static String randomArrayEntry(DemoDataContext ctx, String[] array) {
+        return array[randomArrayIndex(ctx, array.length)];
+    }
+
+    private static <T> T randomArrayEntry(DemoDataContext ctx, List<T> list) {
+        return list.get(randomArrayIndex(ctx, list.size()));
+    }
+
+    /**
+     * Deterministic replacement for the prior "last digits of currentTimeMillis"
+     * suffix — uses ctx.random() to avoid wall-clock reads.
+     */
+    private static String randomSuffix(DemoDataContext ctx) {
+        return randomSuffix(ctx, 4);
+    }
+
+    private static String randomSuffix(DemoDataContext ctx, int digits) {
+        int bound = (int) Math.pow(10, digits);
+        int n = ctx.random().nextInt(bound);
+        String format = "%0" + digits + "d";
+        return String.format(format, n);
+    }
+
+    private static boolean flipACoin(DemoDataContext ctx) {
+        return randomBetween(ctx, 0, 1) == 0;
+    }
+
+    // ---- Static name/text tables (order-stable, so deterministic) ----
+
+    private static final String[] GENDERS = {"M", "F"};
+
+    private static final String[] MALE_FIRST_NAMES = { "James", "John", "Robert", "Michael", "William", "David", "Richard",
+            "Joseph", "Charles", "Thomas", "Christopher", "Daniel", "Matthew", "Donald", "Anthony", "Paul", "Mark",
+            "George", "Steven", "Kenneth", "Andrew", "Edward", "Brian", "Joshua", "Kevin" };
+
+    private static final String[] FEMALE_FIRST_NAMES = { "Mary", "Patricia", "Elizabeth", "Jennifer", "Linda", "Barbara",
+            "Susan", "Margaret", "Jessica", "Dorothy", "Sarah", "Karen", "Nancy", "Betty", "Lisa", "Sandra", "Helen",
+            "Donna", "Ashley", "Kimberly", "Carol", "Michelle", "Amanda", "Emily", "Melissa" };
+
+    private static final String[] FAMILY_NAMES = { "Smith", "Johnson", "Williams", "Brown", "Jones", "Miller", "Davis",
+            "García", "Rodríguez", "Wilson", "Martínez", "Anderson", "Taylor", "Thomas", "Hernández", "Moore", "Martin",
+            "Jackson", "Thompson", "White", "López", "Lee", "González", "Harris", "Clark", "Lewis", "Robinson", "Walker",
+            "Pérez", "Hall", "Young", "Allen", "Sánchez", "Wright", "King", "Scott", "Green", "Baker", "Adams", "Nelson",
+            "Hill", "Ramírez", "Campbell", "Mitchell", "Roberts", "Carter", "Phillips", "Evans", "Turner", "Torres" };
+
+    private static final String[] RANDOM_TEXT = {
+            "Lorem ipsum dolor sit amet",
+            "consectetur adipisicing elit",
+            "sed do eiusmod tempor incididunt",
+            "ut labore et dolore magna aliqua",
+            "Ut enim ad minim veniam",
+            "quis nostrud exercitation ullamco laboris",
+            "nisi ut aliquip ex ea commodo consequat.",
+            "Duis aute irure dolor in reprehenderit in voluptat",
+            "velit esse cillum dolore eu fugiat nulla pariatur.",
+            "Excepteur sint occaecat cupidatat non proident",
+            "sunt in culpa qui officia deserunt",
+            "mollit anim id est laborum." };
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/ReferenceDemoDataActivator.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/ReferenceDemoDataActivator.java
@@ -15,63 +15,37 @@ package org.openmrs.module.referencedemodata;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.WeakHashMap;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalDateTime;
-import org.joda.time.Period;
-import org.openmrs.Concept;
-import org.openmrs.ConceptNumeric;
-import org.openmrs.Encounter;
-import org.openmrs.Form;
 import org.openmrs.GlobalProperty;
-import org.openmrs.Location;
-import org.openmrs.Obs;
-import org.openmrs.Patient;
-import org.openmrs.PatientIdentifier;
-import org.openmrs.PatientIdentifierType;
 import org.openmrs.Person;
-import org.openmrs.PersonAddress;
 import org.openmrs.PersonName;
 import org.openmrs.Provider;
 import org.openmrs.Role;
 import org.openmrs.User;
-import org.openmrs.Visit;
-import org.openmrs.VisitType;
 import org.openmrs.api.AdministrationService;
-import org.openmrs.api.ConceptService;
-import org.openmrs.api.EncounterService;
-import org.openmrs.api.FormService;
-import org.openmrs.api.ObsService;
-import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UserService;
-import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.BaseModuleActivator;
 import org.openmrs.module.ModuleActivator;
 import org.openmrs.module.ModuleException;
 import org.openmrs.module.ModuleUtil;
-import org.openmrs.module.emrapi.EmrApiConstants;
 import org.openmrs.module.emrapi.utils.MetadataUtil;
-import org.openmrs.module.idgen.service.IdentifierSourceService;
 import org.openmrs.module.metadatadeploy.api.MetadataDeployService;
 import org.openmrs.module.metadatadeploy.bundle.MetadataBundle;
 import org.openmrs.module.providermanagement.ProviderRole;
 import org.openmrs.module.providermanagement.api.ProviderManagementService;
-import org.openmrs.module.referencemetadata.ReferenceMetadataConstants;
+import org.openmrs.module.referencedemodata.fixture.ConceptAliases;
+import org.openmrs.module.referencedemodata.fixture.FixturePatientLoader;
 import org.openmrs.util.OpenmrsConstants;
-import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
 
@@ -81,10 +55,6 @@ import org.openmrs.util.RoleConstants;
 public class ReferenceDemoDataActivator extends BaseModuleActivator {
 
 	protected Log log = LogFactory.getLog(getClass());
-	private IdentifierSourceService iss;	// So unit test can mock it.
-    private static Random ConstRand=new Random(0);
-    
-    private Map<String, Concept> cachedConcepts = new WeakHashMap<String, Concept>();
 
 	/**
 	 * @see ModuleActivator#contextRefreshed()
@@ -93,7 +63,7 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
     public void contextRefreshed() {
 		log.info("Reference Demo Data Module refreshed");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#started()
 	 * @should install the metadata package on startup
@@ -111,15 +81,13 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
         createSchedulerUserAndGPs();
         createAppointmentTypes();
         createDemoPatients();
-        
-        cachedConcepts.clear();
 	}
-	
+
 	private void createAppointmentTypes() {
 		MetadataBundle bundle = Context.getRegisteredComponent("appointmentschedulingMetadata", MetadataBundle.class);
 		Context.getService(MetadataDeployService.class).installBundles(Arrays.asList(bundle));
 	}
-	
+
 	private void installMDSPackages() {
 		try {
 			MetadataUtil.setupStandardMetadata(getClass().getClassLoader(), "org/openmrs/module/referencedemodata/packages.xml");
@@ -127,12 +95,12 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
 		catch (Exception e) {
 			throw new ModuleException("Failed to load reference demo data MDS packages", e);
 		}
-		
+
 		log.info("Reference Demo Data Module started");
 	}
-	
+
 	private void linkAdminAccountToAProviderIfNecessary() {
-		
+
 		PrivilegeCompatibility privilegeCompatibility = Context.getRegisteredComponents(PrivilegeCompatibility.class).get(0);
 
 		try {
@@ -236,14 +204,14 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
 
 		return person;
 	}
-	
+
 	private void setRequiredGlobalProperties() {
 		AdministrationService as = Context.getAdministrationService();
 		Map<String, String> propertyValueMap = new HashMap<String, String>();
 		//Add more GPs here
 		propertyValueMap.put("registrationcore.identifierSourceId", "1");
 		propertyValueMap.put(ReferenceDemoDataConstants.CREATE_DEMO_PATIENTS_ON_NEXT_STARTUP, "0");
-		
+
 		for (Map.Entry<String, String> entry : propertyValueMap.entrySet()) {
 			if (StringUtils.isBlank(as.getGlobalProperty(entry.getKey()))) {
 				GlobalProperty gp = as.getGlobalPropertyObject(entry.getKey());
@@ -279,7 +247,7 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
 				"       <string>cityVillage stateProvince country postalCode</string>\n" +
 				"     </lineByLineFormat>\n" +
 				"   </org.openmrs.layout.address.AddressTemplate>");
-		
+
 		//versions before platform 2.0 use a package in web
 		if (!ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, "2.*")) {
 			gp = new GlobalProperty("layout.address.format", "<org.openmrs.layout.web.address.AddressTemplate>\n" +
@@ -306,9 +274,9 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
 					"     </lineByLineFormat>\n" +
 					"   </org.openmrs.layout.web.address.AddressTemplate>");
 		}
-		
+
 		as.saveGlobalProperty(gp);
-				
+
 		//Hack to address RA-631 - clear out bogus default regex for patient name validation
 		//and then blanks out the global property if it contains the bogus entry set by platform
 		//TODO this can be removed once the 1.11.3 platform is released with the fix
@@ -347,347 +315,45 @@ public class ReferenceDemoDataActivator extends BaseModuleActivator {
         }
     }
 
-    // TODO Move all this demo-patient stuff to a separate class.
 	private void createDemoPatients() {
-		AdministrationService as = Context.getAdministrationService();
-
+		// Two-layer gate: runtime property is an operator-level hard disable that survives
+		// regardless of DB state (e.g. cloning a prod DB where the GP is accidentally set).
+		// The GP counter is the per-startup trigger.
 		if ("false".equalsIgnoreCase(Context.getRuntimeProperties()
 				.getProperty(ReferenceDemoDataConstants.CREATE_DEMO_PATIENTS, "true"))) {
 			return;
 		}
 
-		GlobalProperty gp = as.getGlobalPropertyObject(ReferenceDemoDataConstants.CREATE_DEMO_PATIENTS_ON_NEXT_STARTUP);
-		if (gp == null || (gp.getPropertyValue().equals("0"))) {
+		AdministrationService svc = Context.getAdministrationService();
+		int count = parseIntSafely(svc.getGlobalProperty(
+				ReferenceDemoDataConstants.CREATE_DEMO_PATIENTS_ON_NEXT_STARTUP, "0"));
+		if (count <= 0) {
 			return;
 		}
-		createVitalsForm();
-		OpenmrsUtil.applyLogLevel(getClass().getName(), OpenmrsConstants.LOG_LEVEL_INFO);	// force the "created demo patient" below to show up
-		
-		int patientCount = Integer.parseInt(gp.getPropertyValue());
 
-		PatientService ps = Context.getPatientService();
-		Location rootLocation = randomArrayEntry(Context.getLocationService().getRootLocations(false));
-		PatientIdentifierType patientIdentifierType = ps.getPatientIdentifierTypeByName(ReferenceMetadataConstants.OPENMRS_ID_NAME);
-		for (int i = 0; i < patientCount; i++) {
-			Patient patient = createDemoPatient(ps, patientIdentifierType, rootLocation);
-			log.info("created demo patient: " + patient.getPatientIdentifier() + " " + patient.getGivenName() + " " + patient.getFamilyName());
-			Context.flushSession();
-			Context.clearSession();
+		DemoDataContext ctx = DemoDataContext.fromGlobalProperties(svc);
+		DemoProvider.ensure();
+
+		FixturePatientLoader fixtures = new FixturePatientLoader(
+				ConceptAliases.fromClasspath("fixtures/concepts.yaml"));
+		int fixtureCount = fixtures.loadAll(ctx);
+		int remaining = Math.max(0, count - fixtureCount);
+
+		new RandomPatientGenerator().generate(ctx, remaining);
+
+		// Preserve prior behavior: reset the GP so we don't regenerate on every restart.
+		svc.setGlobalProperty(ReferenceDemoDataConstants.CREATE_DEMO_PATIENTS_ON_NEXT_STARTUP, "0");
+	}
+
+	private int parseIntSafely(String s) {
+		if (s == null) return 0;
+		String trimmed = s.trim();
+		if (trimmed.isEmpty()) return 0;
+		try {
+			return Integer.parseInt(trimmed);
+		} catch (NumberFormatException e) {
+			log.warn("Could not parse GP '" + s + "' as int; falling back to 0");
+			return 0;
 		}
-
-		// Set the global to zero so we won't create demo patients next time.
-		gp.setPropertyValue("0");
-		as.saveGlobalProperty(gp);
-    }
-
-	// A bit of a hack - see https://tickets.openmrs.org/browse/RA-264. 
-	private void createVitalsForm() {
-		FormService fs = Context.getFormService();
-		if (fs.getFormByUuid(ReferenceDemoDataConstants.VITALS_FORM_UUID) != null) {
-			return;
-		}
-		Form form = new Form();
-		form.setUuid(ReferenceDemoDataConstants.VITALS_FORM_UUID);
-		form.setName(ReferenceDemoDataConstants.VITALS_FORM_NAME);
-		form.setEncounterType(Context.getEncounterService().getEncounterTypeByUuid(ReferenceDemoDataConstants.VITALS_FORM_ENCOUNTERTYPE_UUID));
-		form.setVersion("1.0");
-		fs.saveForm(form);
-    }
-
-	private Patient createDemoPatient(PatientService ps, PatientIdentifierType patientIdentifierType, Location location) {
-	    Patient patient = createBasicDemoPatient(patientIdentifierType, location);
-		patient = ps.savePatient(patient);
-	    VisitService vs = Context.getVisitService();
-	    int visitCount = randomBetween(0, 10);
-	    for (int i = 0; i < visitCount; i++) {
-	    	boolean shortVisit = i < (visitCount * 0.75);
-	    	Visit visit = createDemoVisit(patient, vs.getAllVisitTypes(), location, shortVisit);
-			vs.saveVisit(visit);
-        }
-	    return patient;
-    }
-
-	// Used by unit test
-    public void setIdentifierSourceService(IdentifierSourceService iss) {
-    	this.iss = iss;
-    }
-
-	private IdentifierSourceService getIdentifierSourceService() {
-		if (iss == null) {
-			iss = Context.getService(IdentifierSourceService.class);
-		}
-		return iss;
 	}
-
-	private Patient createBasicDemoPatient(PatientIdentifierType patientIdentifierType, Location location) {
-		Patient patient = new Patient();
-		
-		PersonName pName = new PersonName();
-		String gender = randomArrayEntry(GENDERS);
-		boolean male = gender.equals("M");
-		pName.setGivenName(randomArrayEntry(male ? MALE_FIRST_NAMES : FEMALE_FIRST_NAMES));
-		pName.setFamilyName(randomArrayEntry(FAMILY_NAMES));
-		patient.addName(pName);
-		
-		PersonAddress pAddress = new PersonAddress();
-		String randomSuffix = randomSuffix();
-		pAddress.setAddress1("Address1" + randomSuffix);
-		pAddress.setCityVillage("City" + randomSuffix);
-		pAddress.setStateProvince("State" + randomSuffix);
-		pAddress.setCountry("Country" + randomSuffix);
-		pAddress.setPostalCode(randomSuffix(5));
-		patient.addAddress(pAddress);
-		
-		patient.setBirthdate(randomBirthdate());
-		patient.setBirthdateEstimated(false);
-		patient.setGender(gender);
-		
-		PatientIdentifier pa1 = new PatientIdentifier();
-		pa1.setIdentifier(getIdentifierSourceService().generateIdentifier(patientIdentifierType, "DemoData"));
-		pa1.setIdentifierType(patientIdentifierType);
-		pa1.setDateCreated(new Date());
-		pa1.setLocation(location);
-		patient.addIdentifier(pa1);
-
-		return patient;
-	}
-	
-	private static final int ADMISSION_DAYS_MIN = 1;
-	private static final int ADMISSION_DAYS_MAX = 3;
-	
-	private Visit createDemoVisit(Patient patient, List<VisitType> visitTypes, Location location, boolean shortVisit) {
-		LocalDateTime visitStart = LocalDateTime.now().minus(Period.days(randomBetween(0, 365*2)).withHours(3));	// past 2 years
-		if (!shortVisit) {
-			visitStart = visitStart.minus(Period.days(ADMISSION_DAYS_MAX+1));	// just in case the start is today, back it up a few days.
-		}
-		Visit visit = new Visit(patient, randomArrayEntry(visitTypes), visitStart.toDate());
-		visit.setLocation(location);
-		LocalDateTime vitalsTime = visitStart.plus(Period.minutes(randomBetween(1, 60)));
-		visit.addEncounter(createDemoVitalsEncounter(patient, vitalsTime.toDate()));
-		LocalDateTime visitNoteTime = visitStart.plus(Period.minutes(randomBetween(60, 120)));
-		visit.addEncounter(createVisitNote(patient, visitNoteTime.toDate(), location));
-		if (shortVisit) {
-			LocalDateTime visitEndTime = visitNoteTime.plus(Period.minutes(30));
-			visit.setStopDatetime(visitEndTime.toDate());
-		} else {
-			// admit now and discharge a few days later
-			Location admitLocation = Context.getLocationService().getLocation("Inpatient Ward");
-			visit.addEncounter(createEncounter("Admission", patient, visitNoteTime.toDate(), admitLocation));
-			LocalDateTime dischargeDateTime = visitNoteTime.plus(Period.days(randomBetween(ADMISSION_DAYS_MIN, ADMISSION_DAYS_MAX)));
-			visit.addEncounter(createEncounter("Discharge", patient, dischargeDateTime.toDate(), admitLocation));
-			visit.setStopDatetime(dischargeDateTime.toDate());
-		}
-		return visit;
-	}
-	
-	private Encounter createVisitNote(Patient patient, Date encounterTime, Location location) {
-		ObsService os = Context.getObsService();
-		ConceptService cs = Context.getConceptService();
-	    Encounter visitNote = createEncounter("Visit Note", patient, encounterTime, location);
-	    visitNote.setForm(Context.getFormService().getForm("Visit Note"));
-	    Context.getEncounterService().saveEncounter(visitNote);
-	    
-	    createTextObs("Text of encounter note"/*CIEL:162169*/, randomArrayEntry(RANDOM_TEXT), patient, visitNote, encounterTime, location, os, cs);
-
-	    createDiagnosisObsGroup(true, patient, visitNote, encounterTime, location, os, cs);
-	    
-	    if (flipACoin()) {
-	    	// add a second diagnosis
-		    createDiagnosisObsGroup(false, patient, visitNote, encounterTime, location, os, cs);
-	    }
-
-	    return visitNote;
-    }
-
-	private void createDiagnosisObsGroup(boolean primary, Patient patient, Encounter visitNote, Date encounterTime,
-                                    Location location, ObsService os, ConceptService cs) {
-		Obs obsGroup = createBasicObs("Visit Diagnoses", patient, encounterTime, location, cs);
-	    visitNote.addObs(obsGroup);
-		
-		// Here we are going to make global property set to true. Reason, is while fetching concepts the case for concept name is different 
-		// from what we are sending to service call. This causes problem in PostgreSQL. This is not a problem in MySQL because For MySQL, 
-		// the collation is utf8_general_ci that is case insensitive so case does not matter but in other dbs like PostgreSQL it does.
-		boolean valueBefore = Context.getAdministrationService().isDatabaseStringComparisonCaseSensitive();
-		Context.getAdministrationService().setGlobalProperty(OpenmrsConstants.GP_CASE_SENSITIVE_DATABASE_STRING_COMPARISON,
-		    "true");
-		
-	    String certainty = flipACoin() ? "Presumed diagnosis" : "Confirmed diagnosis";
-	    Obs obs1 = createCodedObs(EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_CERTAINTY, certainty, patient, visitNote, encounterTime, location, os, cs);
-	    
-	    // TODO 5% of diagnoses should be non-coded.
-	    List<Concept> allDiagnoses = cs.getConceptsByClass(cs.getConceptClassByName("Diagnosis"));
-	    Obs obs2 = createCodedObs("DIAGNOSIS LIST", randomArrayEntry(allDiagnoses), patient, visitNote, encounterTime, location, os, cs);
-	    
-	    String order = primary ? EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER_PRIMARY : EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER_SECONDARY;
-	    Obs obs3 = createCodedObs(EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER, order, patient, visitNote, encounterTime, location, os, cs);
-	    
-	    obsGroup.addGroupMember(obs1);
-	    obsGroup.addGroupMember(obs2);
-	    obsGroup.addGroupMember(obs3);
-	    os.saveObs(obsGroup, "testing");
-		
-		// Restore the value of Global Property
-		Context.getAdministrationService().setGlobalProperty(OpenmrsConstants.GP_CASE_SENSITIVE_DATABASE_STRING_COMPARISON,
-		    String.valueOf(valueBefore));
-	}
-
-	private Encounter createDemoVitalsEncounter(Patient patient, Date encounterTime) {
-		Location location = Context.getLocationService().getLocation("Outpatient Clinic");
-		Encounter encounter = createEncounter("Vitals", patient, encounterTime, location);
-	    encounter.setForm(Context.getFormService().getForm("Vitals"));
-		createDemoVitalsObs(patient, encounter, encounterTime, location);
-		return encounter;
-	}
-	
-	private Encounter createEncounter(String encounterType, Patient patient, Date encounterTime, Location location) {
-		EncounterService es = Context.getEncounterService();
-		Encounter encounter = new Encounter();
-		encounter.setEncounterDatetime(encounterTime);
-		encounter.setEncounterType(es.getEncounterType(encounterType));
-		encounter.setPatient(patient);
-		encounter.setLocation(location);
-		es.saveEncounter(encounter);
-		return encounter;
-	}
-	
-	private void createDemoVitalsObs(Patient patient, Encounter encounter, Date encounterTime, Location location) {
-		ObsService os = Context.getObsService();
-		ConceptService cs = Context.getConceptService();
-        createNumericObs("Height (cm)", 10, 228, patient, encounter, encounterTime, location, os, cs);
-        createNumericObs("Weight (kg)", 1, 250, patient, encounter, encounterTime, location, os, cs);
-        createNumericObs("Temperature (C)", 25, 43, patient, encounter, encounterTime, location, os, cs);
-        createNumericObs("Pulse", 0, 230, patient, encounter, encounterTime, location, os, cs);
-        createNumericObs("Respiratory rate", 5, 100, patient, encounter, encounterTime, location, os, cs);
-		createNumericObs("Systolic blood pressure", 0, 250, patient, encounter, encounterTime, location, os, cs);
-		createNumericObs("Diastolic blood pressure", 0, 150, patient, encounter, encounterTime, location, os, cs);
-        createNumericObs("Blood oxygen saturation", 0, 100, patient, encounter, encounterTime, location, os, cs);
-	}
-
-	private void createNumericObs(String conceptName, int min, int max, Patient patient, Encounter encounter, Date encounterTime, Location location,
-                                  ObsService os, ConceptService cs) {
-		Obs obs = createBasicObs(conceptName, patient, encounterTime, location, cs);
-		
-		Concept concept = obs.getConcept();
-		if (concept != null) {
-			ConceptNumeric conceptNumeric = cs.getConceptNumeric(concept.getConceptId());
-			if (conceptNumeric.getHiAbsolute() != null) {
-				max = conceptNumeric.getHiAbsolute().intValue();
-			}
-			if (conceptNumeric.getLowAbsolute() != null) {
-				min = conceptNumeric.getLowAbsolute().intValue();
-			}
-		}
-		
-		obs.setValueNumeric((double) randomBetween(min, max));
-		encounter.addObs(obs);
-		os.saveObs(obs, null);
-		
-    }
-	
-	private void createTextObs(String conceptName, String text, Patient patient, Encounter encounter, Date encounterTime,
-	                           Location location, ObsService os, ConceptService cs) {
-		Obs obs = createBasicObs(conceptName, patient, encounterTime, location, cs);
-		obs.setValueText(text);
-		encounter.addObs(obs);
-		os.saveObs(obs, null);
-		
-	}
-	
-	private Obs createCodedObs(String conceptName, String codedConceptName, Patient patient, Encounter encounter, Date encounterTime,
-	                           Location location, ObsService os, ConceptService cs) {
-		return createCodedObs(conceptName, findConcept(codedConceptName, cs), patient, encounter, encounterTime, location, os, cs);
-	}
-
-	private Concept findConcept(String conceptName, ConceptService cs) {
-		if (cachedConcepts.containsKey(conceptName)) {
-			return cachedConcepts.get(conceptName);
-		} else {
-			Concept concept = cs.getConcept(conceptName);
-			cachedConcepts.put(conceptName, concept);
-			return concept;
-		}
-    }
-	
-	private Obs createCodedObs(String conceptName, Concept concept, Patient patient, Encounter encounter,
-                               Date encounterTime, Location location, ObsService os, ConceptService cs) {
-		Obs obs = createBasicObs(conceptName, patient, encounterTime, location, cs);
-		obs.setValueCoded(concept);
-		encounter.addObs(obs);
-		os.saveObs(obs, null);
-		return obs;
-    }
-
-	private Obs createBasicObs(String conceptName, Patient patient, Date encounterTime, Location location, ConceptService cs) {
-		Concept concept = findConcept(conceptName, cs);
-		if (concept == null) {
-			log.warn("incorrect concept name? " + conceptName);
-		}
-		return new Obs(patient, concept, encounterTime, location);
-	}
-	
-	private static final int MIN_AGE = 2;
-	private static final int MAX_AGE = 90;
-	
-	private Date randomBirthdate() {
-		LocalDate now = LocalDate.now();
-		LocalDate joda = new LocalDate(randomBetween(now.getYear() - MAX_AGE, now.getYear() - MIN_AGE), randomBetween(1,12), randomBetween(1, 28));
-	    return joda.toDate();
-    }
-
-	static private int randomBetween(int min, int max) {
-	    return min + (int) (ConstRand.nextDouble() * (max-min+1));
-    }
-	static int randomArrayIndex(int length) {
-		return (int) (ConstRand.nextDouble() * length);
-	}
-	static int randomArrayIndex(String[] array) {
-		return randomArrayIndex(array.length);
-	}
-	static String randomArrayEntry(String[] array) {
-		return array[randomArrayIndex(array)];
-	}
-	static <T> T randomArrayEntry(List<T> list) {
-		return list.get(randomArrayIndex(list.size()));
-	}
-	static String randomSuffix() {
-		return randomSuffix(4);
-	}
-	static String randomSuffix(int digits) {
-		// Last n digits of the current time.
-		return StringUtils.right(String.valueOf(System.currentTimeMillis()), digits);
-	}
-	static boolean flipACoin() {
-		return randomBetween(0,1) == 0;
-	}
-
-	private static final String[] GENDERS = {"M", "F"};
-	
-	private static final String[] MALE_FIRST_NAMES = { "James", "John", "Robert", "Michael", "William", "David", "Richard",
-        "Joseph", "Charles", "Thomas", "Christopher", "Daniel", "Matthew", "Donald", "Anthony", "Paul", "Mark",
-        "George", "Steven", "Kenneth", "Andrew", "Edward", "Brian", "Joshua", "Kevin" };
-
-	private static final String[] FEMALE_FIRST_NAMES = { "Mary", "Patricia", "Elizabeth", "Jennifer", "Linda", "Barbara",
-        "Susan", "Margaret", "Jessica", "Dorothy", "Sarah", "Karen", "Nancy", "Betty", "Lisa", "Sandra", "Helen",
-        "Donna", "Ashley", "Kimberly", "Carol", "Michelle", "Amanda", "Emily", "Melissa" };
-
-	private static final String[] FAMILY_NAMES = { "Smith", "Johnson", "Williams", "Brown", "Jones", "Miller", "Davis",
-        "García", "Rodríguez", "Wilson", "Martínez", "Anderson", "Taylor", "Thomas", "Hernández", "Moore", "Martin",
-        "Jackson", "Thompson", "White", "López", "Lee", "González", "Harris", "Clark", "Lewis", "Robinson", "Walker",
-        "Pérez", "Hall", "Young", "Allen", "Sánchez", "Wright", "King", "Scott", "Green", "Baker", "Adams", "Nelson",
-        "Hill", "Ramírez", "Campbell", "Mitchell", "Roberts", "Carter", "Phillips", "Evans", "Turner", "Torres" };
-	
-	private static final String[] RANDOM_TEXT = {
-		"Lorem ipsum dolor sit amet", 
-		"consectetur adipisicing elit", 
-		"sed do eiusmod tempor incididunt", 
-		"ut labore et dolore magna aliqua",
-		"Ut enim ad minim veniam", 
-		"quis nostrud exercitation ullamco laboris",
-		"nisi ut aliquip ex ea commodo consequat.",
-		"Duis aute irure dolor in reprehenderit in voluptat",
-		"velit esse cillum dolore eu fugiat nulla pariatur.",
-		"Excepteur sint occaecat cupidatat non proident", 
-		"sunt in culpa qui officia deserunt",
-		"mollit anim id est laborum."};
-	
 }

--- a/api/src/main/java/org/openmrs/module/referencedemodata/ReferenceDemoDataConstants.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/ReferenceDemoDataConstants.java
@@ -42,4 +42,12 @@ public class ReferenceDemoDataConstants {
 	public static final String VITALS_FORM_UUID = "a000cb34-9ec1-4344-a1c8-f692232f6edd";
 	public static final String VITALS_FORM_ENCOUNTERTYPE_UUID = "67a71486-1a54-468f-ac3e-7091a9a79584";
 	public static final String VITALS_FORM_NAME = "Vitals";
+
+	public static final String DEMO_IDGEN_SOURCE_NAME = "DemoData";
+	public static final String DEMO_PROVIDER_UUID = "c4a8f07f-4de0-4e77-9d79-5d6c0b8d3a02";
+	public static final String CONSULTATION_ENCOUNTER_TYPE_UUID = "dd528487-82a5-4082-9c72-ed246bd49591";
+	public static final String DEMO_PROVIDER_PERSON_UUID = "c4a8f07f-4de0-4e77-9d79-5d6c0b8d3a03";
+
+	public static final String CARE_SETTING_OUTPATIENT_UUID = "6f0c9a92-6f24-11e3-af88-005056821db0";
+	public static final String CARE_SETTING_INPATIENT_UUID = "c365e560-c3ec-11e3-9c1a-0800200c9a66";
 }

--- a/api/src/main/java/org/openmrs/module/referencedemodata/fixture/ConceptAliases.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/fixture/ConceptAliases.java
@@ -1,0 +1,69 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.openmrs.Concept;
+import org.openmrs.api.context.Context;
+import org.yaml.snakeyaml.Yaml;
+
+public final class ConceptAliases {
+
+    public static final class Ref {
+        public final String uuid;
+        public final String ciel;
+        private Ref(String uuid, String ciel) { this.uuid = uuid; this.ciel = ciel; }
+    }
+
+    private final Map<String, Ref> map;
+    private final Map<String, Concept> cache = new HashMap<>();
+
+    private ConceptAliases(Map<String, Ref> map) { this.map = map; }
+
+    public static ConceptAliases fromClasspath(String path) {
+        try (InputStream in = ConceptAliases.class.getClassLoader().getResourceAsStream(path)) {
+            if (in == null) throw new IllegalStateException("missing classpath resource: " + path);
+            Yaml y = new Yaml();
+            Map<String, Map<String, Object>> raw;
+            try {
+                raw = y.load(in);
+            } catch (org.yaml.snakeyaml.error.YAMLException e) {
+                throw new IllegalStateException("failed to parse " + path + ": " + e.getMessage(), e);
+            }
+            Map<String, Ref> refs = new LinkedHashMap<>();
+            for (Map.Entry<String, Map<String, Object>> e : raw.entrySet()) {
+                String alias = e.getKey();
+                Object uuid = e.getValue().get("uuid");
+                Object ciel = e.getValue().get("ciel");
+                if (uuid == null && ciel == null) {
+                    throw new IllegalStateException("malformed alias entry '" + alias + "' in " + path + ": needs uuid or ciel");
+                }
+                refs.put(alias, new Ref(
+                        uuid == null ? null : uuid.toString(),
+                        ciel == null ? null : ciel.toString()));
+            }
+            return new ConceptAliases(refs);
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("failed to read " + path, e);
+        }
+    }
+
+    public Concept resolve(String alias) {
+        Concept cached = cache.get(alias);
+        if (cached != null) return cached;
+        Ref ref = map.get(alias);
+        if (ref == null) throw new IllegalStateException("unknown concept alias: " + alias);
+        Concept c = null;
+        if (ref.uuid != null) {
+            c = Context.getConceptService().getConceptByUuid(ref.uuid);
+        } else if (ref.ciel != null) {
+            c = Context.getConceptService().getConceptByMapping(ref.ciel, "CIEL");
+        }
+        if (c == null) {
+            throw new IllegalStateException("concept alias " + alias + " did not resolve (uuid=" + ref.uuid + ", ciel=" + ref.ciel + ")");
+        }
+        cache.put(alias, c);
+        return c;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/fixture/FixtureDiscovery.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/fixture/FixtureDiscovery.java
@@ -1,0 +1,29 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Tiny discovery over classpath:fixtures/index.txt. Avoids classpath-scanning magic. */
+public final class FixtureDiscovery {
+    private FixtureDiscovery() {}
+
+    public static List<String> listFixtureResources() {
+        try (InputStream in = FixtureDiscovery.class.getClassLoader()
+                .getResourceAsStream("fixtures/index.txt")) {
+            if (in == null) return Collections.emptyList();
+            return new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))
+                    .lines()
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty() && !s.startsWith("#"))
+                    .map(s -> "fixtures/" + s)
+                    .collect(Collectors.toList());
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("failed to read fixtures/index.txt", e);
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/fixture/FixturePatient.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/fixture/FixturePatient.java
@@ -1,0 +1,58 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FixturePatient {
+    public String uuid;
+    public String identifier;          // optional; default DEMO-NNNNNNNNNN
+    public String givenName;
+    public String familyName;
+    public String gender;              // "M" / "F" / "U"
+    public String birthdate;           // "-P65Y"
+    public Address address;
+    public List<Condition> conditions = new ArrayList<>();
+    public List<Allergy> allergies = new ArrayList<>();
+    public List<Visit> visits = new ArrayList<>();
+    public List<Order> orders = new ArrayList<>();
+    public List<Lab> labs = new ArrayList<>();
+
+    public static class Address { public String city, state, country, postalCode; }
+    public static class Condition { public String uuid; public String alias; public String onset; public String status; /* active|inactive */ }
+    public static class Allergy   { public String uuid; public String allergen; public String severity; public String reaction; }
+    public static class Visit {
+        public String uuid;
+        public String date;            // "-P1M"
+        public String type;            // "outpatient" | "inpatient"
+        public List<Encounter> encounters = new ArrayList<>();
+    }
+    public static class Encounter {
+        public String uuid;
+        public String type;            // alias: VISIT_NOTE, VITALS, ADMISSION, DISCHARGE, CONSULTATION
+        public List<Obs> obs = new ArrayList<>();
+        public String noteText;        // stored as Obs on TEXT_OF_ENCOUNTER if present
+    }
+    public static class Obs {
+        public String uuid;
+        public String concept;         // alias into concepts.yaml
+        public Double value;           // numeric obs only (MVP)
+    }
+    public static class Order {
+        public String uuid;
+        public String drug;            // alias: DRUG_HCTZ etc
+        public Double dose;
+        public String doseUnits;       // e.g. "mg"
+        public String route;           // e.g. "PO"
+        public String frequency;       // e.g. "daily", "twice daily", "four times daily"
+        public String careSetting;     // "outpatient" | "inpatient"; default "outpatient"
+        public String indication;      // alias: DX_HTN etc
+        public String startDate;       // "-P25Y"
+        public Integer durationDays;   // optional
+        public String status;          // "active" | "inactive"
+    }
+    public static class Lab {
+        public String concept;         // alias
+        public String date;            // "-P29D"
+        public Double value;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/fixture/FixturePatientLoader.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/fixture/FixturePatientLoader.java
@@ -1,0 +1,329 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import org.openmrs.Concept;
+import org.openmrs.Drug;
+import org.openmrs.DrugOrder;
+import org.openmrs.Encounter;
+import org.openmrs.EncounterType;
+import org.openmrs.Location;
+import org.openmrs.Obs;
+import org.openmrs.Order;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.PersonAddress;
+import org.openmrs.PersonName;
+import org.openmrs.Provider;
+import org.openmrs.SimpleDosingInstructions;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.referencedemodata.DemoDataContext;
+import org.openmrs.module.referencedemodata.DemoIdentifiers;
+import org.openmrs.module.referencedemodata.DemoProvider;
+import org.openmrs.module.referencedemodata.ReferenceDemoDataConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+public class FixturePatientLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(FixturePatientLoader.class);
+
+    private final ConceptAliases aliases;
+
+    public FixturePatientLoader(ConceptAliases aliases) { this.aliases = aliases; }
+
+    /** Loads every fixture listed in fixtures/index.txt. */
+    public int loadAll(DemoDataContext ctx) {
+        int total = 0;
+        for (String path : FixtureDiscovery.listFixtureResources()) {
+            total += loadOne(path, ctx);
+        }
+        return total;
+    }
+
+    /**
+     * Loads a single fixture, persisting the Patient row and then best-effort-attaching visits,
+     * conditions, orders, and labs.
+     *
+     * @return 1 once the Patient is persisted (regardless of whether downstream clinical data
+     *         attached successfully); 0 if the patient UUID already exists.
+     */
+    public int loadOne(String classpathPath, DemoDataContext ctx) {
+        FixturePatient fx = read(classpathPath);
+        if (Context.getPatientService().getPatientByUuid(fx.uuid) != null) {
+            log.info("Skipping fixture " + classpathPath + " (patient UUID " + fx.uuid + " already exists)");
+            return 0;
+        }
+        Location location = getDefaultLocation();
+        PatientIdentifierType idType = DemoIdentifiers.type();
+
+        Patient p = new Patient();
+        p.setUuid(fx.uuid);
+        p.setGender(fx.gender);
+        p.setBirthdate(Date.from(RelativeTime.resolve(fx.birthdate, ctx.clockAnchor())));
+        PersonName name = new PersonName(fx.givenName, null, fx.familyName);
+        p.addName(name);
+        if (fx.address != null) {
+            PersonAddress a = new PersonAddress();
+            a.setCityVillage(fx.address.city);
+            a.setStateProvince(fx.address.state);
+            a.setCountry(fx.address.country);
+            a.setPostalCode(fx.address.postalCode);
+            p.addAddress(a);
+        }
+        PatientIdentifier pid = new PatientIdentifier(
+                fx.identifier != null ? fx.identifier : DemoIdentifiers.next(),
+                idType, location);
+        pid.setPreferred(true);
+        p.addIdentifier(pid);
+        Context.getPatientService().savePatient(p);
+
+        // Catch IllegalStateException specifically: that's what our metadata-lookup helpers
+        // (pickVisitType, lookupConceptByName, firstDrugForConcept, ConceptAliases.resolve, etc.)
+        // throw when the dictionary is missing a referenced concept/drug/visit-type. OpenMRS
+        // core APIs throw APIException/HibernateException for genuine runtime bugs — those
+        // propagate so structural problems don't ship silently.
+        try {
+            Provider orderer = DemoProvider.ensure();
+            for (FixturePatient.Visit v : fx.visits) {
+                createVisit(p, v, ctx, location, orderer);
+            }
+            for (FixturePatient.Condition c : fx.conditions) {
+                createCondition(p, c, ctx, location);
+            }
+            for (FixturePatient.Order o : fx.orders) {
+                createOrder(p, o, ctx, orderer);
+            }
+            createLabs(p, fx, ctx, location);
+        } catch (IllegalStateException e) {
+            log.warn("Fixture " + classpathPath + " patient saved but clinical data incomplete: "
+                    + e.getMessage(), e);
+        }
+        return 1;
+    }
+
+    private FixturePatient read(String classpathPath) {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(classpathPath)) {
+            if (in == null) throw new IllegalStateException("missing " + classpathPath);
+            Yaml y = new Yaml(new Constructor(FixturePatient.class, new LoaderOptions()));
+            try {
+                return y.load(in);
+            } catch (org.yaml.snakeyaml.error.YAMLException e) {
+                throw new IllegalStateException("failed to parse fixture " + classpathPath + ": " + e.getMessage(), e);
+            }
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("failed to read " + classpathPath, e);
+        }
+    }
+
+    private Location getDefaultLocation() {
+        Location loc = Context.getLocationService().getDefaultLocation();
+        if (loc != null) return loc;
+        List<Location> all = Context.getLocationService().getAllLocations();
+        if (all == null || all.isEmpty()) {
+            throw new IllegalStateException("no default location and getAllLocations() is empty");
+        }
+        Location fallback = all.iterator().next();
+        log.warn("No default location configured; attaching demo data to first available location: "
+                + fallback.getName());
+        return fallback;
+    }
+
+    private void createVisit(Patient p, FixturePatient.Visit vf, DemoDataContext ctx, Location loc, Provider orderer) {
+        Instant when = RelativeTime.resolve(vf.date, ctx.clockAnchor());
+        Visit v = new Visit();
+        v.setUuid(vf.uuid);
+        v.setPatient(p);
+        v.setLocation(loc);
+        v.setStartDatetime(Date.from(when));
+        v.setVisitType(pickVisitType(vf.type));
+        // Save the visit before encounters so each encounter references a persistent Visit.
+        Context.getVisitService().saveVisit(v);
+        for (FixturePatient.Encounter ef : vf.encounters) {
+            createEncounter(v, ef, ctx, when, loc, orderer);
+        }
+        v.setStopDatetime(Date.from(when.plusSeconds(3600)));
+        Context.getVisitService().saveVisit(v);
+    }
+
+    private VisitType pickVisitType(String kind) {
+        List<VisitType> all = Context.getVisitService().getAllVisitTypes();
+        String wanted = "inpatient".equalsIgnoreCase(kind) ? "Inpatient" : "Outpatient";
+        for (VisitType vt : all) if (vt.getName().equalsIgnoreCase(wanted)) return vt;
+        throw new IllegalStateException("no VisitType named '" + wanted + "' (requested kind=" + kind + ")");
+    }
+
+    private void createEncounter(Visit v, FixturePatient.Encounter ef, DemoDataContext ctx, Instant when, Location loc, Provider orderer) {
+        EncounterType type = Context.getEncounterService().getEncounterTypeByUuid(resolveEncounterTypeUuid(ef.type));
+        Encounter e = new Encounter();
+        e.setUuid(ef.uuid);
+        e.setEncounterType(type);
+        e.setPatient(v.getPatient());
+        e.setEncounterDatetime(Date.from(when));
+        e.setLocation(loc);
+        e.setVisit(v);
+        Context.getEncounterService().saveEncounter(e);
+
+        for (FixturePatient.Obs of : ef.obs) {
+            Obs obs = new Obs();
+            obs.setUuid(of.uuid);
+            obs.setPerson(v.getPatient());
+            obs.setObsDatetime(e.getEncounterDatetime());
+            obs.setEncounter(e);
+            obs.setConcept(aliases.resolve(of.concept));
+            obs.setValueNumeric(of.value);
+            Context.getObsService().saveObs(obs, null);
+        }
+        if (ef.noteText != null && !ef.noteText.isEmpty()) {
+            Obs textObs = new Obs();
+            textObs.setPerson(v.getPatient());
+            textObs.setObsDatetime(e.getEncounterDatetime());
+            textObs.setEncounter(e);
+            textObs.setConcept(aliases.resolve("TEXT_OF_ENCOUNTER"));
+            textObs.setValueText(ef.noteText);
+            Context.getObsService().saveObs(textObs, null);
+        }
+    }
+
+    private String resolveEncounterTypeUuid(String alias) {
+        switch (alias) {
+            case "VISIT_NOTE":   return "d7151f82-c1f3-4152-a605-2f9ea7414a79";
+            case "ADMISSION":    return "e22e39fd-7db2-45e7-80f1-60fa0d5a4378";
+            case "DISCHARGE":    return "181820aa-88c9-479b-9077-af92f5364329";
+            case "VITALS":       return "67a71486-1a54-468f-ac3e-7091a9a79584";
+            case "CONSULTATION": return ReferenceDemoDataConstants.CONSULTATION_ENCOUNTER_TYPE_UUID;
+            default: throw new IllegalArgumentException("unknown encounter type alias: " + alias);
+        }
+    }
+
+    private void createCondition(Patient p, FixturePatient.Condition cf, DemoDataContext ctx, Location loc) {
+        // Problem list is stored as Obs on CIEL 1284 (Problem added) with valueCoded = diagnosis concept.
+        // status: ignored on 1.12 — no core ConditionService.
+        // Needs an anchor encounter dated at onset.
+        java.time.Instant onset = RelativeTime.resolve(cf.onset, ctx.clockAnchor());
+        Encounter anchor = new Encounter();
+        anchor.setEncounterType(Context.getEncounterService()
+                .getEncounterTypeByUuid(ReferenceDemoDataConstants.CONSULTATION_ENCOUNTER_TYPE_UUID));
+        anchor.setPatient(p);
+        anchor.setEncounterDatetime(java.util.Date.from(onset));
+        anchor.setLocation(loc);
+        Context.getEncounterService().saveEncounter(anchor);
+
+        Obs problem = new Obs();
+        problem.setUuid(cf.uuid);
+        problem.setPerson(p);
+        problem.setObsDatetime(anchor.getEncounterDatetime());
+        problem.setEncounter(anchor);
+        problem.setConcept(aliases.resolve("PROBLEM_ADDED"));
+        problem.setValueCoded(aliases.resolve(cf.alias));
+        Context.getObsService().saveObs(problem, null);
+    }
+
+    private void createOrder(Patient p, FixturePatient.Order of, DemoDataContext ctx, Provider orderer) {
+        DrugOrder o = new DrugOrder();
+        o.setUuid(of.uuid);
+        o.setPatient(p);
+        Concept drugConcept = aliases.resolve(of.drug);
+        Drug drug = firstDrugForConcept(drugConcept, of.uuid);
+        o.setDrug(drug);
+        o.setConcept(drugConcept);
+        if (of.dose == null) {
+            throw new IllegalStateException("fixture order " + of.uuid + " is missing required 'dose'");
+        }
+        o.setDose(of.dose);
+        o.setDoseUnits(lookupConceptByName(of.doseUnits, of.uuid));
+        o.setRoute(lookupConceptByName(of.route, of.uuid));
+        o.setFrequency(lookupFrequencyByName(of.frequency, of.uuid));
+        o.setDosingType(SimpleDosingInstructions.class);
+        o.setUrgency(Order.Urgency.ROUTINE);
+        o.setCareSetting(Context.getOrderService().getCareSettingByUuid(
+                "inpatient".equalsIgnoreCase(of.careSetting)
+                        ? ReferenceDemoDataConstants.CARE_SETTING_INPATIENT_UUID
+                        : ReferenceDemoDataConstants.CARE_SETTING_OUTPATIENT_UUID));
+        o.setDateActivated(Date.from(RelativeTime.resolve(of.startDate, ctx.clockAnchor())));
+        o.setOrderer(orderer);
+        o.setAction(Order.Action.NEW);
+        if (of.durationDays != null) {
+            o.setDuration(of.durationDays);
+            o.setDurationUnits(lookupConceptByName("Days", of.uuid));
+        }
+        // Orders need an encounter; synthesize one anchored at startDate.
+        Encounter syntheticEnc = new Encounter();
+        syntheticEnc.setEncounterType(Context.getEncounterService()
+                .getEncounterTypeByUuid(ReferenceDemoDataConstants.CONSULTATION_ENCOUNTER_TYPE_UUID));
+        syntheticEnc.setPatient(p);
+        syntheticEnc.setEncounterDatetime(o.getDateActivated());
+        syntheticEnc.setLocation(getDefaultLocation());
+        Context.getEncounterService().saveEncounter(syntheticEnc);
+        o.setEncounter(syntheticEnc);
+        Context.getOrderService().saveOrder(o, null);
+    }
+
+    private void createLabs(Patient p, FixturePatient fx, DemoDataContext ctx, Location loc) {
+        java.util.Map<String, Encounter> byDate = new java.util.TreeMap<>();
+        for (FixturePatient.Lab lab : fx.labs) {
+            Encounter e = byDate.get(lab.date);
+            if (e == null) {
+                java.time.Instant when = RelativeTime.resolve(lab.date, ctx.clockAnchor());
+                e = new Encounter();
+                e.setEncounterType(Context.getEncounterService()
+                        .getEncounterTypeByUuid(ReferenceDemoDataConstants.CONSULTATION_ENCOUNTER_TYPE_UUID));
+                e.setPatient(p);
+                e.setEncounterDatetime(java.util.Date.from(when));
+                e.setLocation(loc);
+                Context.getEncounterService().saveEncounter(e);
+                byDate.put(lab.date, e);
+            }
+            Obs obs = new Obs();
+            obs.setPerson(p);
+            obs.setObsDatetime(e.getEncounterDatetime());
+            obs.setEncounter(e);
+            obs.setConcept(aliases.resolve(lab.concept));
+            obs.setValueNumeric(lab.value);
+            Context.getObsService().saveObs(obs, null);
+        }
+    }
+
+    private Drug firstDrugForConcept(Concept concept, String fixtureUuid) {
+        List<Drug> drugs = Context.getConceptService().getDrugsByConcept(concept);
+        if (drugs == null || drugs.isEmpty()) {
+            throw new IllegalStateException("fixture order " + fixtureUuid
+                    + ": no Drug found for concept " + (concept == null ? "null" : concept.getUuid()));
+        }
+        return drugs.stream()
+                .sorted(java.util.Comparator.comparing(Drug::getUuid))
+                .findFirst().orElseThrow(() -> new IllegalStateException(
+                        "fixture order " + fixtureUuid + ": no Drug found for concept "
+                                + (concept == null ? "null" : concept.getUuid())));
+    }
+
+    private Concept lookupConceptByName(String name, String fixtureUuid) {
+        if (name == null) return null;
+        Concept c = Context.getConceptService().getConceptByName(name);
+        if (c == null) {
+            throw new IllegalStateException("fixture " + fixtureUuid + ": missing concept named '" + name + "'");
+        }
+        return c;
+    }
+
+    private org.openmrs.OrderFrequency lookupFrequencyByName(String name, String fixtureUuid) {
+        if (name == null) return null;
+        Concept concept = Context.getConceptService().getConceptByName(name);
+        if (concept == null) {
+            throw new IllegalStateException("fixture " + fixtureUuid + ": missing frequency concept named '" + name + "'");
+        }
+        org.openmrs.OrderFrequency freq = Context.getOrderService().getOrderFrequencyByConcept(concept);
+        if (freq == null) {
+            throw new IllegalStateException("fixture " + fixtureUuid + ": no OrderFrequency for concept '" + name + "'");
+        }
+        return freq;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/referencedemodata/fixture/RelativeTime.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/fixture/RelativeTime.java
@@ -1,0 +1,24 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+
+public final class RelativeTime {
+    private RelativeTime() {}
+
+    /** Resolves "-P25Y", "-P2Y11M", "-P29D" against anchor. Positive offsets rejected: demo data must be in the past. */
+    public static Instant resolve(String s, Instant anchor) {
+        if (s == null || !s.startsWith("-P")) {
+            throw new IllegalArgumentException("expected ISO-8601 negative period like '-P25Y'; got: " + s);
+        }
+        Period p;
+        try {
+            p = Period.parse(s.substring(1)); // strip leading minus
+        } catch (Exception e) {
+            throw new IllegalArgumentException("invalid period: " + s, e);
+        }
+        return LocalDateTime.ofInstant(anchor, ZoneOffset.UTC).minus(p).toInstant(ZoneOffset.UTC);
+    }
+}

--- a/api/src/main/resources/fixtures/concepts.yaml
+++ b/api/src/main/resources/fixtures/concepts.yaml
@@ -1,0 +1,44 @@
+# Alias -> concept reference. Two forms accepted:
+#   uuid: <OpenMRS UUID>
+#   ciel: <CIEL numeric code>   # resolves via ConceptService.getConceptByMapping("CIEL", code)
+# Fixtures reference these aliases instead of inlining raw UUIDs.
+
+# --- Vitals (UUIDs from module CSVs) ---
+SYSTOLIC_BP: { uuid: 5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DIASTOLIC_BP: { uuid: 5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+PULSE:       { uuid: 5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+RESP_RATE:   { uuid: 5242AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+SPO2:        { uuid: 5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+TEMP_C:      { uuid: 5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+WEIGHT_KG:   { uuid: 5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+HEIGHT_CM:   { uuid: 5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+
+# --- Encounter text obs ---
+TEXT_OF_ENCOUNTER: { uuid: 162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+
+# --- Labs (CIEL mappings; resolve on first load, fail loudly if missing) ---
+HGB:      { ciel: "21" }
+WBC:      { ciel: "678" }
+PLT:      { ciel: "729" }
+NA:       { ciel: "654" }
+BUN:      { ciel: "857" }
+CR:       { ciel: "790" }
+K:        { uuid: 1133AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+GLUCOSE:  { ciel: "887" }
+HBA1C:    { ciel: "159644" }
+
+# --- Diagnosis concepts ---
+PROBLEM_ADDED: { ciel: "1284" }
+DX_DM2:       { ciel: "142474" }
+DX_HTN:       { ciel: "117399" }
+DX_PUD:       { ciel: "143957" }
+DX_H_PYLORI:  { ciel: "136443" }
+
+# --- Drug concepts ---
+DRUG_HCTZ:                 { uuid: 77696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DRUG_AMLODIPINE:           { uuid: 71137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DRUG_METFORMIN:            { uuid: 79651AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DRUG_ESOMEPRAZOLE:         { uuid: 75875AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DRUG_BISMUTH_SUBSALICYLATE: { uuid: 72241AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DRUG_TETRACYCLINE:         { uuid: 84893AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }
+DRUG_METRONIDAZOLE:        { uuid: 79782AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA }

--- a/api/src/main/resources/fixtures/devan-modi.yaml
+++ b/api/src/main/resources/fixtures/devan-modi.yaml
@@ -1,0 +1,228 @@
+# Source: docs/fixtures/devan-modi-source.pdf
+uuid: 22222222-2222-2222-2222-000000000001
+givenName: Devan
+familyName: Modi
+gender: M
+birthdate: "-P65Y"
+address: { city: Boston, state: MA, country: US, postalCode: "02115" }
+
+conditions:
+  - { uuid: 22222222-2222-2222-2222-000000001001, alias: DX_DM2, onset: "-P5Y",  status: active }
+  - { uuid: 22222222-2222-2222-2222-000000001002, alias: DX_HTN, onset: "-P25Y", status: active }
+  - { uuid: 22222222-2222-2222-2222-000000001003, alias: DX_PUD, onset: "-P1M",  status: active }
+
+visits:
+  # Hospitalization 1 month ago for PUD / H. pylori
+  - uuid: 22222222-2222-2222-2222-000000002001
+    date: "-P1M"
+    type: inpatient
+    encounters:
+      - uuid: 22222222-2222-2222-2222-000000003001
+        type: VITALS
+        obs:
+          - { uuid: 22222222-2222-2222-2222-000000004001, concept: SYSTOLIC_BP,  value: 140 }
+          - { uuid: 22222222-2222-2222-2222-000000004002, concept: DIASTOLIC_BP, value: 76 }
+          - { uuid: 22222222-2222-2222-2222-000000004003, concept: PULSE,        value: 90 }
+          - { uuid: 22222222-2222-2222-2222-000000004004, concept: RESP_RATE,    value: 14 }
+          - { uuid: 22222222-2222-2222-2222-000000004005, concept: SPO2,         value: 99 }
+          - { uuid: 22222222-2222-2222-2222-000000004006, concept: TEMP_C,       value: 37.2 }
+          - { uuid: 22222222-2222-2222-2222-000000004007, concept: WEIGHT_KG,    value: 83 }
+          - { uuid: 22222222-2222-2222-2222-000000004008, concept: HEIGHT_CM,    value: 177 }
+      - uuid: 22222222-2222-2222-2222-000000003002
+        type: DISCHARGE
+        noteText: |
+          Hospital: Memorial Hospital
+          Patient: Devan Modi, DOB (age 65)
+          Admission Date: 30 days ago
+          Discharge Date: 28 days ago
+          Admission Diagnosis: Upper GI bleed
+          Discharge Diagnosis: Bleeding peptic ulcer disease 2/2 H. pylori
+          Attending physician: Dr. Jina Hsu
+          Consultations: Gastroenterology
+          Procedures: Upper endoscopy
+          H&P: Mr. Modi is a 65-year-old man who presented to the emergency department for
+          epigastric pain of 3 days duration and one episode of coffee ground emesis on the
+          morning of presentation. His past medical history is significant for hypertension
+          and type 2 diabetes. His medications prior to admission were HCTZ, amlodipine, and
+          metformin. His vital signs were stable. Abdominal exam revealed epigastric tenderness
+          without rebound or guarding. A rectal exam showed heme+ stool. His hemoglobin was
+          9.6, down from his baseline of 13.1.
+          Hospital Course: The patient was admitted for a presumed upper GI bleed. Two large
+          bore IVs were placed and the patient was given iv fluids and started on a PPI drip.
+          His HCTZ, amlodipine and metformin were held. GI was consulted and the patient
+          underwent an EGD which showed a non-bleeding gastric ulcer. Biopsies were taken and
+          were positive for H. pylori. Post-EGD Hgb was stable at 9.3. The patient was started
+          on bismuth quadruple therapy. The patient's pain improved and his diet was advanced.
+          He experienced no additional bleeding during his hospitalization. His hemoglobin
+          remained stable and was 9.5 on discharge.
+          Discharge Diagnosis: Bleeding peptic ulcer disease 2/2 H. pylori
+          Discharge Condition: Stable
+          Signed by Jina Hsu, MD
+      - uuid: 22222222-2222-2222-2222-000000003003
+        type: CONSULTATION
+        noteText: |
+          Procedure Note, 29 days ago.
+          Study: Esophagogastroduodenoscopy (EGD)
+          PATIENT: Devan Modi
+          PHYSICIAN: Dr. Joshua Schull
+          INDICATION: Upper GI Bleed
+          FINDINGS: Esophagus: normal. GE junction at 39 CM. No hiatal hernia.
+          Stomach: Coffee ground material present. Non-bleeding gastric ulcer in the fundus,
+          erythematous surrounding mucosa. Biopsies taken.
+          Duodenum: No mucosal abnormality.
+          IMPRESSION: Non-bleeding gastric ulcer.
+          Signed: Dr. Joshua Schull
+
+  # Follow-up with NP 4 weeks after the 3-year-ago visit = ~2y11mo ago
+  - uuid: 22222222-2222-2222-2222-000000002002
+    date: "-P2Y11M"
+    type: outpatient
+    encounters:
+      - uuid: 22222222-2222-2222-2222-000000003004
+        type: VITALS
+        obs:
+          - { uuid: 22222222-2222-2222-2222-000000004020, concept: SYSTOLIC_BP,  value: 138 }
+          - { uuid: 22222222-2222-2222-2222-000000004021, concept: DIASTOLIC_BP, value: 78 }
+          - { uuid: 22222222-2222-2222-2222-000000004022, concept: PULSE,        value: 82 }
+          - { uuid: 22222222-2222-2222-2222-000000004023, concept: RESP_RATE,    value: 13 }
+          - { uuid: 22222222-2222-2222-2222-000000004024, concept: TEMP_C,       value: 38.2 }
+      - uuid: 22222222-2222-2222-2222-000000003005
+        type: VISIT_NOTE
+        noteText: |
+          NP Visit, blood pressure check.
+          Pt: Devan Modi. Nurse Practitioner: Sara Renault.
+          Subjective: Follow-up for BP check after amlodipine 5mg was added 4 weeks ago.
+          Home readings 120s-130s / 70s-80s. Tolerating amlodipine well. No SOB, CP, LE swelling.
+          Objective: BP 138/78, HR 82, RR 13, Temp 38.2.
+          Assessment: 62 y/o with HTN and T2DM, BP now acceptable.
+          Plan: Continue amlodipine and HCTZ. Monitor at home.
+          Signed: Sara Renault
+
+  # Initial amlodipine-addition visit, 3 years ago
+  - uuid: 22222222-2222-2222-2222-000000002003
+    date: "-P3Y"
+    type: outpatient
+    encounters:
+      - uuid: 22222222-2222-2222-2222-000000003006
+        type: VITALS
+        obs:
+          - { uuid: 22222222-2222-2222-2222-000000004040, concept: SYSTOLIC_BP,  value: 168 }
+          - { uuid: 22222222-2222-2222-2222-000000004041, concept: DIASTOLIC_BP, value: 92 }
+          - { uuid: 22222222-2222-2222-2222-000000004042, concept: PULSE,        value: 80 }
+          - { uuid: 22222222-2222-2222-2222-000000004043, concept: RESP_RATE,    value: 16 }
+          - { uuid: 22222222-2222-2222-2222-000000004044, concept: SPO2,         value: 98 }
+          - { uuid: 22222222-2222-2222-2222-000000004045, concept: TEMP_C,       value: 38.2 }
+          - { uuid: 22222222-2222-2222-2222-000000004046, concept: WEIGHT_KG,    value: 81.5 }
+          - { uuid: 22222222-2222-2222-2222-000000004047, concept: HEIGHT_CM,    value: 177 }
+      - uuid: 22222222-2222-2222-2222-000000003007
+        type: VISIT_NOTE
+        noteText: |
+          Visit Note, 3 years ago.
+          Pt: Devan Modi. PCP: Luis Perez.
+          Subjective: 62 y/o man, home BP log 150-165/85-90. Taking HCTZ 50mg daily, metformin
+          1000 mg twice daily. Denies headache, vision changes, chest pain, SOB.
+          Objective: BP 168/92, HR 80, RR 16, Temp 98.6F.
+          Labs: Fasting glucose 110, HbA1c 6.2, BMP WNL.
+          Assessment: HTN + T2DM with elevated BP despite HCTZ.
+          Plan: Start amlodipine 5 mg daily. Continue HCTZ 50mg daily. Re-evaluate in 4 weeks.
+          Continue metformin 1000 mg BID.
+          Signed: Luis Perez
+
+  # DM diagnosis visit, 5 years ago
+  - uuid: 22222222-2222-2222-2222-000000002004
+    date: "-P5Y"
+    type: outpatient
+    encounters:
+      - uuid: 22222222-2222-2222-2222-000000003008
+        type: VITALS
+        obs:
+          - { uuid: 22222222-2222-2222-2222-000000004060, concept: SYSTOLIC_BP,  value: 130 }
+          - { uuid: 22222222-2222-2222-2222-000000004061, concept: DIASTOLIC_BP, value: 68 }
+          - { uuid: 22222222-2222-2222-2222-000000004062, concept: PULSE,        value: 82 }
+          - { uuid: 22222222-2222-2222-2222-000000004063, concept: RESP_RATE,    value: 14 }
+          - { uuid: 22222222-2222-2222-2222-000000004064, concept: SPO2,         value: 99 }
+          - { uuid: 22222222-2222-2222-2222-000000004065, concept: TEMP_C,       value: 37.8 }
+          - { uuid: 22222222-2222-2222-2222-000000004066, concept: WEIGHT_KG,    value: 81 }
+          - { uuid: 22222222-2222-2222-2222-000000004067, concept: HEIGHT_CM,    value: 177 }
+      - uuid: 22222222-2222-2222-2222-000000003009
+        type: VISIT_NOTE
+        noteText: |
+          Visit Note, 5 years ago.
+          Pt: Devan Modi. PCP: Luis Perez.
+          Subjective: 60 y/o for routine physical. Elevated screening glucose; follow-up A1c
+          elevated. History of HTN on HCTZ.
+          Objective: BP 140/85, HR 70, RR 16, Temp 98.6F.
+          Labs: Fasting glucose 154, HbA1c 7.1.
+          Assessment: New T2DM.
+          Plan: Start metformin 500mg daily, titrate to 1000 mg BID. Diabetes education.
+          Dietary counseling. Follow up 4-6 weeks. Continue HCTZ.
+          Signed: Luis Perez
+
+# Labs attach to the visits above by date
+labs:
+  - { concept: HGB,     date: "-P28D", value: 9.5 }
+  - { concept: HGB,     date: "-P29D", value: 9.3 }
+  - { concept: HGB,     date: "-P30D", value: 9.6 }
+  - { concept: HGB,     date: "-P3Y",  value: 13.1 }
+  - { concept: WBC,     date: "-P28D", value: 8.2 }
+  - { concept: WBC,     date: "-P29D", value: 8.0 }
+  - { concept: WBC,     date: "-P30D", value: 8.1 }
+  - { concept: WBC,     date: "-P3Y",  value: 7.2 }
+  - { concept: PLT,     date: "-P28D", value: 226 }
+  - { concept: PLT,     date: "-P29D", value: 237 }
+  - { concept: PLT,     date: "-P30D", value: 232 }
+  - { concept: PLT,     date: "-P3Y",  value: 273 }
+  - { concept: NA,      date: "-P28D", value: 140 }
+  - { concept: NA,      date: "-P29D", value: 141 }
+  - { concept: NA,      date: "-P30D", value: 140 }
+  - { concept: NA,      date: "-P3Y",  value: 140 }
+  - { concept: NA,      date: "-P5Y",  value: 142 }
+  - { concept: BUN,     date: "-P28D", value: 13 }
+  - { concept: BUN,     date: "-P29D", value: 12 }
+  - { concept: BUN,     date: "-P30D", value: 20 }
+  - { concept: BUN,     date: "-P3Y",  value: 14 }
+  - { concept: BUN,     date: "-P5Y",  value: 14 }
+  - { concept: CR,      date: "-P28D", value: 0.8 }
+  - { concept: CR,      date: "-P29D", value: 0.8 }
+  - { concept: CR,      date: "-P30D", value: 1.0 }
+  - { concept: CR,      date: "-P3Y",  value: 0.9 }
+  - { concept: CR,      date: "-P5Y",  value: 0.9 }
+  - { concept: K,       date: "-P28D", value: 4.0 }
+  - { concept: K,       date: "-P29D", value: 4.2 }
+  - { concept: K,       date: "-P30D", value: 4.0 }
+  - { concept: K,       date: "-P3Y",  value: 4.1 }
+  - { concept: K,       date: "-P5Y",  value: 4.2 }
+  - { concept: GLUCOSE, date: "-P28D", value: 118 }
+  - { concept: GLUCOSE, date: "-P29D", value: 123 }
+  - { concept: GLUCOSE, date: "-P30D", value: 108 }
+  - { concept: GLUCOSE, date: "-P3Y",  value: 110 }
+  - { concept: GLUCOSE, date: "-P5Y",  value: 154 }
+  - { concept: HBA1C,   date: "-P30D", value: 6.4 }
+  - { concept: HBA1C,   date: "-P3Y",  value: 6.2 }
+  - { concept: HBA1C,   date: "-P5Y",  value: 7.1 }
+
+# Drug orders
+orders:
+  - { uuid: 22222222-2222-2222-2222-000000005001, drug: DRUG_HCTZ,
+      dose: 50,   doseUnits: mg, route: PO, frequency: daily,
+      indication: DX_HTN, startDate: "-P25Y", status: active }
+  - { uuid: 22222222-2222-2222-2222-000000005002, drug: DRUG_AMLODIPINE,
+      dose: 5,    doseUnits: mg, route: PO, frequency: daily,
+      indication: DX_HTN, startDate: "-P3Y", status: active }
+  - { uuid: 22222222-2222-2222-2222-000000005003, drug: DRUG_METFORMIN,
+      dose: 1000, doseUnits: mg, route: PO, frequency: "twice daily",
+      indication: DX_DM2, startDate: "-P5Y", status: active }
+  - { uuid: 22222222-2222-2222-2222-000000005004, drug: DRUG_ESOMEPRAZOLE,
+      dose: 20,   doseUnits: mg, route: PO, frequency: "twice daily",
+      indication: DX_PUD, startDate: "-P28D", status: active }
+  - { uuid: 22222222-2222-2222-2222-000000005005, drug: DRUG_BISMUTH_SUBSALICYLATE,
+      dose: 300,  doseUnits: mg, route: PO, frequency: "four times daily",
+      indication: DX_H_PYLORI, startDate: "-P29D", durationDays: 14, status: inactive }
+  - { uuid: 22222222-2222-2222-2222-000000005006, drug: DRUG_TETRACYCLINE,
+      dose: 500,  doseUnits: mg, route: PO, frequency: "four times daily",
+      indication: DX_H_PYLORI, startDate: "-P29D", durationDays: 14, status: inactive }
+  - { uuid: 22222222-2222-2222-2222-000000005007, drug: DRUG_METRONIDAZOLE,
+      dose: 250,  doseUnits: mg, route: PO, frequency: "four times daily",
+      indication: DX_H_PYLORI, startDate: "-P29D", durationDays: 14, status: inactive }
+
+allergies: []

--- a/api/src/main/resources/fixtures/index.txt
+++ b/api/src/main/resources/fixtures/index.txt
@@ -1,0 +1,2 @@
+# One fixture filename per line. Do not include concepts.yaml here.
+devan-modi.yaml

--- a/api/src/test/java/org/openmrs/module/referencedemodata/DemoDataContextTest.java
+++ b/api/src/test/java/org/openmrs/module/referencedemodata/DemoDataContextTest.java
@@ -1,0 +1,40 @@
+package org.openmrs.module.referencedemodata;
+
+import org.junit.Test;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.Assert.*;
+
+public class DemoDataContextTest {
+
+    @Test
+    public void sameSeedProducesSameRandomSequence() {
+        DemoDataContext a = DemoDataContext.of(42L, Instant.parse("2025-01-01T00:00:00Z"));
+        DemoDataContext b = DemoDataContext.of(42L, Instant.parse("2025-01-01T00:00:00Z"));
+        for (int i = 0; i < 100; i++) {
+            assertEquals(a.random().nextLong(), b.random().nextLong());
+        }
+    }
+
+    @Test
+    public void pickIsDeterministicAcrossIterationOrder() {
+        DemoDataContext ctx = DemoDataContext.of(7L, Instant.parse("2025-01-01T00:00:00Z"));
+        List<String> forwards = Arrays.asList("a", "b", "c", "d", "e");
+        List<String> reversed = Arrays.asList("e", "d", "c", "b", "a");
+        String pickA = ctx.pick(forwards, s -> s);
+        DemoDataContext ctx2 = DemoDataContext.of(7L, Instant.parse("2025-01-01T00:00:00Z"));
+        String pickB = ctx2.pick(reversed, s -> s);
+        assertEquals(pickA, pickB);
+    }
+
+    @Test
+    public void newUuidIsDeterministic() {
+        DemoDataContext a = DemoDataContext.of(1L, Instant.parse("2025-01-01T00:00:00Z"));
+        DemoDataContext b = DemoDataContext.of(1L, Instant.parse("2025-01-01T00:00:00Z"));
+        UUID ua = a.newUuid();
+        UUID ub = b.newUuid();
+        assertEquals(ua, ub);
+    }
+}

--- a/api/src/test/java/org/openmrs/module/referencedemodata/fixture/RelativeTimeTest.java
+++ b/api/src/test/java/org/openmrs/module/referencedemodata/fixture/RelativeTimeTest.java
@@ -1,0 +1,16 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import org.junit.Test;
+import java.time.Instant;
+import static org.junit.Assert.*;
+
+public class RelativeTimeTest {
+    private final Instant anchor = Instant.parse("2025-01-01T00:00:00Z");
+
+    @Test public void parsesYears()  { assertEquals(Instant.parse("2000-01-01T00:00:00Z"), RelativeTime.resolve("-P25Y", anchor)); }
+    @Test public void parsesMonths() { assertEquals(Instant.parse("2024-12-01T00:00:00Z"), RelativeTime.resolve("-P1M", anchor)); }
+    @Test public void parsesDays()   { assertEquals(Instant.parse("2024-12-03T00:00:00Z"), RelativeTime.resolve("-P29D", anchor)); }
+    @Test public void parsesMixedYearsMonths() { assertEquals(Instant.parse("2022-02-01T00:00:00Z"), RelativeTime.resolve("-P2Y11M", anchor)); }
+    @Test(expected = IllegalArgumentException.class) public void rejectsPositive() { RelativeTime.resolve("P1Y", anchor); }
+    @Test(expected = IllegalArgumentException.class) public void rejectsGarbage()  { RelativeTime.resolve("yesterday", anchor); }
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -60,6 +60,21 @@
         </conditionalResource>
     </conditionalResources>
     <!-- / Conditional Resources -->
-    
+
+    <globalProperty>
+        <property>referencedemodata.seed</property>
+        <defaultValue>0</defaultValue>
+        <description>Seed for deterministic demo patient generation (long).</description>
+    </globalProperty>
+    <globalProperty>
+        <property>referencedemodata.clockAnchor</property>
+        <defaultValue>2025-01-01T00:00:00Z</defaultValue>
+        <description>
+            ISO-8601 instant used as "today" by the demo data generator. Hard-coded so two
+            fresh installs produce identical patients. Set explicitly to shift the dataset
+            forward in time.
+        </description>
+    </globalProperty>
+
 </module>
 

--- a/omod/src/test/java/org/openmrs/module/referencedemodata/DemoIdentifiersTest.java
+++ b/omod/src/test/java/org/openmrs/module/referencedemodata/DemoIdentifiersTest.java
@@ -1,0 +1,25 @@
+package org.openmrs.module.referencedemodata;
+
+import org.junit.Test;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.module.referencemetadata.ReferenceMetadataActivator;
+import org.openmrs.module.referencemetadata.ReferenceMetadataConstants;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.SkipBaseSetup;
+import static org.junit.Assert.*;
+
+@SkipBaseSetup
+public class DemoIdentifiersTest extends BaseModuleContextSensitiveTest {
+
+    @Test
+    public void typeResolvesToOpenMRSId() throws Exception {
+        initializeInMemoryDatabase();
+        executeDataSet("requiredDataTestDataset.xml");
+        authenticate();
+        new ReferenceMetadataActivator().started();
+
+        PatientIdentifierType t = DemoIdentifiers.type();
+        assertNotNull("OpenMRS ID type must exist after referencemetadata startup", t);
+        assertEquals(ReferenceMetadataConstants.OPENMRS_ID_NAME, t.getName());
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/referencedemodata/DemoProviderTest.java
+++ b/omod/src/test/java/org/openmrs/module/referencedemodata/DemoProviderTest.java
@@ -1,0 +1,17 @@
+package org.openmrs.module.referencedemodata;
+
+import org.junit.Test;
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import static org.junit.Assert.*;
+
+public class DemoProviderTest extends BaseModuleContextSensitiveTest {
+    @Test
+    public void ensureIsIdempotent() {
+        Provider p1 = DemoProvider.ensure();
+        Provider p2 = DemoProvider.ensure();
+        assertEquals(p1.getUuid(), p2.getUuid());
+        assertEquals(ReferenceDemoDataConstants.DEMO_PROVIDER_UUID, p1.getUuid());
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/referencedemodata/ReferenceDemoDataActivatorTest.java
+++ b/omod/src/test/java/org/openmrs/module/referencedemodata/ReferenceDemoDataActivatorTest.java
@@ -14,6 +14,7 @@
 package org.openmrs.module.referencedemodata;
 
 import org.hibernate.cfg.Environment;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -146,49 +147,45 @@ public class ReferenceDemoDataActivatorTest extends BaseModuleContextSensitiveTe
         adminService.saveGlobalProperty(createDemoPatients);
         
         new ReferenceMetadataActivator().started();
-        
-		ReferenceDemoDataActivator referenceDemoDataActivator = new ReferenceDemoDataActivator();
-        initMockGenerator(referenceDemoDataActivator);
-		referenceDemoDataActivator.started();
+
+        installMockIdentifierSource();
+		new ReferenceDemoDataActivator().started();
 
 		List<Patient> allPatients = patientService.getAllPatients();
-        for (Patient patient : allPatients) {
-	        System.out.println(patient + " " + patient.getPatientIdentifier() + " " + patient.getPersonName() + " " + patient.getBirthdate() + " " + patient.getAddresses());
-        }
 		assertEquals(demoPatientCount, allPatients.size());
         List<Visit> allVisits = visitService.getAllVisits();
-        for (Visit visit : allVisits) {
-	        System.out.println(visit + " " + visit.getStartDatetime() + " - " + visit.getStopDatetime() + " " + visit.getEncounters());
-        }
 		assertTrue(allVisits.size() > demoPatientCount);
     }
-    
-    long seed = 0;
-    SequentialIdentifierGenerator mockIdGenerator;
 
-    private void initMockGenerator(ReferenceDemoDataActivator referenceDemoDataActivator) {
-		PatientIdentifierType openmrsIdType = patientService.getPatientIdentifierTypeByName(ReferenceMetadataConstants.OPENMRS_ID_NAME);
-    	mockIdGenerator = new SequentialIdentifierGenerator();
-    	mockIdGenerator.setIdentifierType(openmrsIdType);
-    	mockIdGenerator.setName(ReferenceMetadataConstants.OPENMRS_ID_GENERATOR_NAME);
-    	mockIdGenerator.setUuid(ReferenceMetadataConstants.OPENMRS_ID_GENERATOR_UUID);
-    	mockIdGenerator.setBaseCharacterSet(new LuhnMod30IdentifierValidator().getBaseCharacters());
-    	mockIdGenerator.setMinLength(6);
-    	mockIdGenerator.setFirstIdentifierBase("10000");
+    @After
+    public void clearMockIdentifierSource() {
+        DemoIdentifiers.setIdentifierSourceService(null);
+    }
+
+    private long seed = 0;
+    private SequentialIdentifierGenerator mockIdGenerator;
+
+    private void installMockIdentifierSource() {
+        PatientIdentifierType openmrsIdType = patientService
+                .getPatientIdentifierTypeByName(ReferenceMetadataConstants.OPENMRS_ID_NAME);
+        mockIdGenerator = new SequentialIdentifierGenerator();
+        mockIdGenerator.setIdentifierType(openmrsIdType);
+        mockIdGenerator.setName(ReferenceMetadataConstants.OPENMRS_ID_GENERATOR_NAME);
+        mockIdGenerator.setUuid(ReferenceMetadataConstants.OPENMRS_ID_GENERATOR_UUID);
+        mockIdGenerator.setBaseCharacterSet(new LuhnMod30IdentifierValidator().getBaseCharacters());
+        mockIdGenerator.setMinLength(6);
+        mockIdGenerator.setFirstIdentifierBase("10000");
 
         IdentifierSourceService mockIss = Mockito.mock(IdentifierSourceService.class);
-        Mockito.when(mockIss.generateIdentifier(Mockito.eq(openmrsIdType), Mockito.eq("DemoData"))).thenAnswer(new Answer<String>() {
-        	@Override
-        	public String answer(InvocationOnMock invocation) throws Throwable {
-        	    return generateIdentifier();
-        	}
-        });
-        referenceDemoDataActivator.setIdentifierSourceService(mockIss);
+        Mockito.when(mockIss.generateIdentifier(Mockito.eq(openmrsIdType),
+                Mockito.eq(ReferenceDemoDataConstants.DEMO_IDGEN_SOURCE_NAME)))
+                .thenAnswer(new Answer<String>() {
+                    @Override
+                    public String answer(InvocationOnMock invocation) throws Throwable {
+                        seed++;
+                        return mockIdGenerator.getIdentifierForSeed(seed);
+                    }
+                });
+        DemoIdentifiers.setIdentifierSourceService(mockIss);
     }
-    
-    private String generateIdentifier() {
-    	seed++;
-	    return mockIdGenerator.getIdentifierForSeed(seed);
-    }
-    
 }

--- a/omod/src/test/java/org/openmrs/module/referencedemodata/ReproducibilityTest.java
+++ b/omod/src/test/java/org/openmrs/module/referencedemodata/ReproducibilityTest.java
@@ -1,0 +1,313 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ */
+package org.openmrs.module.referencedemodata;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.openmrs.Concept;
+import org.openmrs.Encounter;
+import org.openmrs.Obs;
+import org.openmrs.Visit;
+
+import org.hibernate.cfg.Environment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.PersonAddress;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.idgen.SequentialIdentifierGenerator;
+import org.openmrs.module.idgen.service.IdentifierSourceService;
+import org.openmrs.module.idgen.validator.LuhnMod30IdentifierValidator;
+import org.openmrs.module.referencemetadata.ReferenceMetadataActivator;
+import org.openmrs.module.referencemetadata.ReferenceMetadataConstants;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.SkipBaseSetup;
+
+/**
+ * Asserts that random demo-patient generation is reproducible given a fixed seed,
+ * down through visits, encounters, and obs values.
+ *
+ * <p>Hashes every ctx-derived field: patient names / gender / birthdate / address,
+ * visit datetimes + type UUID, encounter datetimes + type UUID, and each obs's
+ * concept UUID + value. Uses UUIDs rather than names so locale-sensitive
+ * {@code Concept.getName()} can't smuggle non-determinism into the hash.
+ *
+ * <p>Excludes:
+ * <ul>
+ *   <li>Patient identifiers — idgen owns the sequence and is outside the ctx contract.</li>
+ *   <li>Hibernate-assigned row UUIDs and primary keys — non-deterministic regardless
+ *       of seed.</li>
+ * </ul>
+ *
+ * <p>Determinism at the obs layer depends on {@code RandomPatientGenerator} using
+ * {@code ctx.pick(list, stableKey)} (not {@code randomArrayEntry}) for any list
+ * that comes back from the DB — otherwise locale-preferred concept-name sorting
+ * in {@code ConceptService.getConceptsByClass} or session-state-dependent ordering
+ * in {@code VisitService.getAllVisitTypes} would desynchronise the RNG.
+ */
+@SkipBaseSetup
+public class ReproducibilityTest extends BaseModuleContextSensitiveTest {
+
+    private static final Instant CLOCK_ANCHOR = Instant.parse("2025-01-01T00:00:00Z");
+    private static final long SEED = 42L;
+    private static final int PATIENT_COUNT = 3;
+
+    private long idgenCounter;
+    private long idgenSeedOffset;
+    private SequentialIdentifierGenerator mockIdGenerator;
+    private Locale originalLocale;
+    private TimeZone originalTimeZone;
+
+    @Override
+    public Properties getRuntimeProperties() {
+        Properties props = super.getRuntimeProperties();
+        String url = props.getProperty(Environment.URL);
+        if (url != null && url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
+            props.setProperty(Environment.URL, url + ";MVCC=true");
+        }
+        return props;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        initializeInMemoryDatabase();
+        executeDataSet("requiredDataTestDataset.xml");
+        authenticate();
+        new ReferenceMetadataActivator().started();
+        // Also run the demo module's activator for its MDS packages (root locations, forms,
+        // etc.) that RandomPatientGenerator depends on. The GP defaults to 0 so no patients
+        // are created here — those come from the explicit generate() call below.
+        new ReferenceDemoDataActivator().started();
+        originalLocale = Locale.getDefault();
+        originalTimeZone = TimeZone.getDefault();
+    }
+
+    @After
+    public void tearDown() {
+        DemoIdentifiers.setIdentifierSourceService(null);
+        if (originalLocale != null) Locale.setDefault(originalLocale);
+        if (originalTimeZone != null) TimeZone.setDefault(originalTimeZone);
+    }
+
+    @Test
+    public void sameSeedYieldsIdenticalCtxDerivedHash() throws Exception {
+        Locale.setDefault(Locale.US);
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+
+        String h1 = generateAndHashNew();
+        // No DB cleanup between runs — UUID-set diff ensures each run hashes only its own
+        // patients. The idgen mock uses a nanoTime offset so identifiers don't collide.
+        String h2 = generateAndHashNew();
+
+        assertEquals("same (seed, clockAnchor) must produce identical ctx-derived output", h1, h2);
+    }
+
+    private String generateAndHashNew() throws Exception {
+        Set<String> before = snapshotPatientUuids();
+        installMockIdentifierSource();
+        DemoDataContext ctx = DemoDataContext.of(SEED, CLOCK_ANCHOR);
+        new RandomPatientGenerator().generate(ctx, PATIENT_COUNT);
+        return hashCtxDerived(patientsAddedSince(before));
+    }
+
+    private Set<String> snapshotPatientUuids() {
+        Set<String> uuids = new HashSet<String>();
+        for (Patient p : Context.getPatientService().getAllPatients()) {
+            uuids.add(p.getUuid());
+        }
+        return uuids;
+    }
+
+    private List<Patient> patientsAddedSince(Set<String> beforeUuids) {
+        List<Patient> fresh = new ArrayList<Patient>();
+        for (Patient p : Context.getPatientService().getAllPatients()) {
+            if (!beforeUuids.contains(p.getUuid())) fresh.add(p);
+        }
+        return fresh;
+    }
+
+    private void installMockIdentifierSource() {
+        idgenCounter = 0;
+        // Large per-run offset so encoded IDs (a) don't collide with MDS pre-baked patients
+        // (which occupy the low 6-char Luhn-mod-30 range) and (b) differ between runs —
+        // identifiers intentionally aren't in the hash.
+        idgenSeedOffset = Math.abs(System.nanoTime());
+        PatientIdentifierType openmrsIdType = Context.getPatientService()
+                .getPatientIdentifierTypeByName(ReferenceMetadataConstants.OPENMRS_ID_NAME);
+        mockIdGenerator = new SequentialIdentifierGenerator();
+        mockIdGenerator.setIdentifierType(openmrsIdType);
+        mockIdGenerator.setName(ReferenceMetadataConstants.OPENMRS_ID_GENERATOR_NAME);
+        mockIdGenerator.setUuid(ReferenceMetadataConstants.OPENMRS_ID_GENERATOR_UUID);
+        mockIdGenerator.setBaseCharacterSet(new LuhnMod30IdentifierValidator().getBaseCharacters());
+        mockIdGenerator.setMinLength(6);
+        mockIdGenerator.setFirstIdentifierBase("100000");
+
+        IdentifierSourceService mockIss = Mockito.mock(IdentifierSourceService.class);
+        Mockito.when(mockIss.generateIdentifier(Mockito.eq(openmrsIdType),
+                Mockito.eq(ReferenceDemoDataConstants.DEMO_IDGEN_SOURCE_NAME)))
+                .thenAnswer(new Answer<String>() {
+                    @Override
+                    public String answer(InvocationOnMock invocation) {
+                        idgenCounter++;
+                        return mockIdGenerator.getIdentifierForSeed(idgenSeedOffset + idgenCounter);
+                    }
+                });
+        DemoIdentifiers.setIdentifierSourceService(mockIss);
+    }
+
+    private String hashCtxDerived(List<Patient> patients) throws Exception {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        Collections.sort(patients, BY_PATIENT_CTX_KEY);
+        for (Patient p : patients) {
+            hashPatient(md, p);
+        }
+        return Base64.getEncoder().encodeToString(md.digest());
+    }
+
+    private void hashPatient(MessageDigest md, Patient p) {
+        putStr(md, p.getGivenName());
+        putStr(md, p.getFamilyName());
+        putStr(md, p.getGender());
+        if (p.getBirthdate() != null) {
+            md.update(longBytes(p.getBirthdate().getTime()));
+        }
+        PersonAddress a = p.getPersonAddress();
+        if (a != null) {
+            putStr(md, a.getAddress1());
+            putStr(md, a.getCityVillage());
+            putStr(md, a.getStateProvince());
+            putStr(md, a.getCountry());
+            putStr(md, a.getPostalCode());
+        }
+        List<Visit> visits = new ArrayList<Visit>(
+                Context.getVisitService().getVisitsByPatient(p));
+        Collections.sort(visits, BY_VISIT_START);
+        for (Visit v : visits) hashVisit(md, v);
+    }
+
+    private void hashVisit(MessageDigest md, Visit v) {
+        putStr(md, v.getVisitType() == null ? null : v.getVisitType().getUuid());
+        if (v.getStartDatetime() != null) md.update(longBytes(v.getStartDatetime().getTime()));
+        if (v.getStopDatetime() != null)  md.update(longBytes(v.getStopDatetime().getTime()));
+        List<Encounter> encs = new ArrayList<Encounter>(
+                Context.getEncounterService().getEncountersByVisit(v, false));
+        Collections.sort(encs, BY_ENCOUNTER_DATETIME_TYPE);
+        for (Encounter e : encs) hashEncounter(md, e);
+    }
+
+    private void hashEncounter(MessageDigest md, Encounter e) {
+        putStr(md, e.getEncounterType() == null ? null : e.getEncounterType().getUuid());
+        if (e.getEncounterDatetime() != null) md.update(longBytes(e.getEncounterDatetime().getTime()));
+        List<Obs> obs = new ArrayList<Obs>(e.getAllObs(false));
+        Collections.sort(obs, BY_OBS_CONCEPT_VALUE);
+        for (Obs o : obs) hashObs(md, o);
+    }
+
+    private void hashObs(MessageDigest md, Obs o) {
+        putStr(md, conceptUuid(o.getConcept()));
+        if (o.getValueNumeric() != null) {
+            md.update(longBytes(Double.doubleToLongBits(o.getValueNumeric())));
+        }
+        putStr(md, o.getValueText());
+        putStr(md, conceptUuid(o.getValueCoded()));
+    }
+
+    private static String conceptUuid(Concept c) { return c == null ? null : c.getUuid(); }
+
+    private static void putStr(MessageDigest md, String s) {
+        if (s == null) {
+            md.update((byte) 0);
+        } else {
+            md.update(s.getBytes(StandardCharsets.UTF_8));
+        }
+        md.update((byte) '|');
+    }
+
+    private static byte[] longBytes(long l) {
+        return ByteBuffer.allocate(8).putLong(l).array();
+    }
+
+    // Anonymous Comparators — avoid method references for consistency with other
+    // context-sensitive tests in this module.
+    private static final Comparator<Patient> BY_PATIENT_CTX_KEY = new Comparator<Patient>() {
+        @Override public int compare(Patient a, Patient b) {
+            int c = Long.compare(
+                    a.getBirthdate() == null ? 0L : a.getBirthdate().getTime(),
+                    b.getBirthdate() == null ? 0L : b.getBirthdate().getTime());
+            if (c != 0) return c;
+            c = nullToEmpty(a.getGivenName()).compareTo(nullToEmpty(b.getGivenName()));
+            if (c != 0) return c;
+            c = nullToEmpty(a.getFamilyName()).compareTo(nullToEmpty(b.getFamilyName()));
+            if (c != 0) return c;
+            PersonAddress aa = a.getPersonAddress();
+            PersonAddress ba = b.getPersonAddress();
+            return nullToEmpty(aa == null ? null : aa.getPostalCode())
+                    .compareTo(nullToEmpty(ba == null ? null : ba.getPostalCode()));
+        }
+    };
+
+    private static final Comparator<Visit> BY_VISIT_START = new Comparator<Visit>() {
+        @Override public int compare(Visit a, Visit b) {
+            return Long.compare(
+                    a.getStartDatetime() == null ? 0L : a.getStartDatetime().getTime(),
+                    b.getStartDatetime() == null ? 0L : b.getStartDatetime().getTime());
+        }
+    };
+
+    private static final Comparator<Encounter> BY_ENCOUNTER_DATETIME_TYPE = new Comparator<Encounter>() {
+        @Override public int compare(Encounter a, Encounter b) {
+            int c = Long.compare(
+                    a.getEncounterDatetime() == null ? 0L : a.getEncounterDatetime().getTime(),
+                    b.getEncounterDatetime() == null ? 0L : b.getEncounterDatetime().getTime());
+            if (c != 0) return c;
+            return nullToEmpty(a.getEncounterType() == null ? null : a.getEncounterType().getUuid())
+                    .compareTo(nullToEmpty(b.getEncounterType() == null ? null : b.getEncounterType().getUuid()));
+        }
+    };
+
+    private static final Comparator<Obs> BY_OBS_CONCEPT_VALUE = new Comparator<Obs>() {
+        @Override public int compare(Obs a, Obs b) {
+            int c = nullToEmpty(conceptUuid(a.getConcept()))
+                    .compareTo(nullToEmpty(conceptUuid(b.getConcept())));
+            if (c != 0) return c;
+            Double av = a.getValueNumeric();
+            Double bv = b.getValueNumeric();
+            if (av != null && bv != null) {
+                c = Double.compare(av, bv);
+                if (c != 0) return c;
+            }
+            c = nullToEmpty(a.getValueText()).compareTo(nullToEmpty(b.getValueText()));
+            if (c != 0) return c;
+            // Tiebreaker: coded value (matters for diagnosis groups where two obs share
+            // the same concept UUID but differ in valueCoded).
+            return nullToEmpty(conceptUuid(a.getValueCoded()))
+                    .compareTo(nullToEmpty(conceptUuid(b.getValueCoded())));
+        }
+    };
+
+    private static String nullToEmpty(String s) { return s == null ? "" : s; }
+}

--- a/omod/src/test/java/org/openmrs/module/referencedemodata/fixture/ConceptAliasesTest.java
+++ b/omod/src/test/java/org/openmrs/module/referencedemodata/fixture/ConceptAliasesTest.java
@@ -1,0 +1,12 @@
+package org.openmrs.module.referencedemodata.fixture;
+
+import org.junit.Test;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+public class ConceptAliasesTest extends BaseModuleContextSensitiveTest {
+    @Test(expected = IllegalStateException.class)
+    public void failsLoudlyForUnknownAlias() {
+        ConceptAliases aliases = ConceptAliases.fromClasspath("fixtures/concepts.yaml");
+        aliases.resolve("DOES_NOT_EXIST");
+    }
+}

--- a/omod/src/test/resources/fixtures/test-minimal.yaml
+++ b/omod/src/test/resources/fixtures/test-minimal.yaml
@@ -1,0 +1,17 @@
+uuid: 11111111-1111-1111-1111-000000000001
+givenName: Test
+familyName: Patient
+gender: M
+birthdate: "-P30Y"
+conditions:
+  - { uuid: 11111111-1111-1111-1111-000000001000, alias: DX_HTN, onset: "-P5Y", status: active }
+visits:
+  - uuid: 11111111-1111-1111-1111-000000002000
+    date: "-P1M"
+    type: outpatient
+    encounters:
+      - uuid: 11111111-1111-1111-1111-000000003000
+        type: VITALS
+        obs:
+          - { uuid: 11111111-1111-1111-1111-000000004000, concept: SYSTOLIC_BP,  value: 140 }
+          - { uuid: 11111111-1111-1111-1111-000000004001, concept: DIASTOLIC_BP, value: 76 }


### PR DESCRIPTION
## Summary

- Thread all sources of non-determinism (seed, clock anchor, RNG, locale) through a single `DemoDataContext`, so a fixed `(seed, clockAnchor)` produces byte-identical demo patients across machines.
- Add a SnakeYAML-backed fixture loader that resolves concepts by UUID or CIEL mapping, and ship a curated `Devan Modi` patient fixture (3 problems, 4 visits incl. PUD hospitalization, vitals per date, 7 drug orders, lab timeline).
- New global properties: `referencedemodata.seed` (default `0`) and `referencedemodata.clockAnchor` (default `2025-01-01T00:00:00Z`).

## Details

- `DemoDataContext`: owns `SplittableRandom(seed)`, `clockAnchor`, deterministic UUID/identifier counters, `Locale.ROOT`. Replaces `ConstRand`, `Instant.now()`, and `new Date()` on every generation path.
- `ctx.pick(collection, keyFn)`: sorts by a stable key (UUIDs, not locale-sensitive names) before RNG pick, so DB/HashMap iteration order can't desync the seeded stream.
- `RandomPatientGenerator`: extracted from the activator; all randomness and time reads route through `ctx`. Visit/encounter dates derive from `ctx.clockAnchor()` instead of wall-clock.
- `FixturePatientLoader`: idempotent load by patient UUID; concept resolution via `concepts.yaml` alias map (UUID or CIEL mapping). Fixtures loaded before random patients.
- Problems stored as `Obs` on CIEL 1284 (Problem added) rather than `ConditionService`, keeping the module on the existing Platform 1.12 baseline.
- Activator orchestrates: fixtures first, then `max(0, count - fixtureCount)` random patients under the existing `referencedemodata.createDemoPatientsOnNextStartup` GP kill-switch.
- `ReproducibilityTest`: runs `generate()` twice with SEED=42 under a forced `Locale.US` / `America/New_York`, SHA-256s every ctx-derived field (names, gender, birthdate, address, visit/encounter datetimes + type UUIDs, obs concept UUIDs + values), asserts equality. Identifiers and row UUIDs are excluded — idgen and Hibernate own those.

## Test plan

- [ ] `mvn clean test` passes on api and omod modules
- [ ] `ReproducibilityTest` passes (two seeded runs yield identical SHA-256)
- [ ] On a fresh Ref App 2.x server with `createDemoPatientsOnNextStartup=N`, verify:
  - [ ] Devan Modi fixture loads with all 4 visits, 7 drug orders, and lab timeline
  - [ ] Remaining `N - 1` random patients generate without error
  - [ ] Running the same server twice from scratch with identical `seed`/`clockAnchor` yields patients with identical names, birthdates, visit counts, and obs values
- [ ] `referencedemodata.createDemoPatientsOnNextStartup` GP resets to 0 after generation