### PR TITLE
Prevent a single invalid generated obs from aborting demo data generation

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencedemodata/obs/DemoObsGenerator.java
+++ b/api/src/main/java/org/openmrs/module/referencedemodata/obs/DemoObsGenerator.java
@@ -37,6 +37,7 @@ import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.api.APIException;
 import org.openmrs.api.ObsService;
+import org.openmrs.api.ValidationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.referencedemodata.DemoDataConceptCache;
@@ -168,10 +169,10 @@ public class DemoObsGenerator {
 		Obs partialObs = ObsValueGenerator.createObsWithNumericValue(descriptor, previousValue);
 		
 		Obs savedObs = createObs(partialObs, patient, encounter, encounterDateTime, location);
-		if (savedObs.getValueNumeric() != null && key.getLeft() != null && key.getRight() != null) {
+		if (savedObs != null && savedObs.getValueNumeric() != null && key.getLeft() != null && key.getRight() != null) {
 			lastNumericValues.put(key, savedObs.getValueNumeric());
 		}
-		
+
 		return savedObs;
 	}
 	
@@ -209,8 +210,28 @@ public class DemoObsGenerator {
 		partialObs.setPerson(patient);
 		partialObs.setObsDatetime(encounterTime);
 		partialObs.setLocation(location);
-		
-		return getObsService().saveObs(partialObs, null);
+
+		// This relies on saveObs running in its own (outermost) transaction, as it does during demo
+		// generation. If this is ever wrapped in a single enclosing transaction that saveObs
+		// participates in, Spring marks that transaction rollback-only before this catch runs, so
+		// catching here would not stop the eventual commit from failing.
+		try {
+			return getObsService().saveObs(partialObs, null);
+		}
+		catch (ValidationException e) {
+			// A randomly generated numeric value can fall outside the concept's reference range.
+			// On platforms >= 2.7 the core ObsValidator validates numeric obs against the applicable
+			// ConceptReferenceRange (which can be narrower than, or defined where there is no,
+			// ConceptNumeric absolute bound that ObsValueGenerator clamps to), so such a value is
+			// rejected here. Skip the single offending obs instead of letting the exception abort
+			// the entire demo data generation.
+			Integer conceptId = partialObs.getConcept() == null ? null : partialObs.getConcept().getConceptId();
+			log.warn("Skipping demo obs for concept [{}] that failed validation: {}", conceptId, e.getMessage());
+			if (encounter != null) {
+				encounter.removeObs(partialObs);
+			}
+			return null;
+		}
 	}
 	
 	private List<NumericObsValueDescriptor> getVitalsDescriptors() {

--- a/api/src/test/java/org/openmrs/module/referencedemodata/obs/DemoObsGeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/referencedemodata/obs/DemoObsGeneratorTest.java
@@ -1,0 +1,77 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.referencedemodata.obs;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.Encounter;
+import org.openmrs.Obs;
+import org.openmrs.Patient;
+import org.openmrs.api.ObsService;
+import org.openmrs.api.ValidationException;
+import org.openmrs.module.referencedemodata.DemoDataConceptCache;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DemoObsGeneratorTest {
+
+	private ObsService obsService;
+
+	private DemoObsGenerator generator;
+
+	@Before
+	public void setup() {
+		obsService = mock(ObsService.class);
+		generator = new DemoObsGenerator(mock(DemoDataConceptCache.class));
+
+		// inject the mocked ObsService so createObs() does not reach into the OpenMRS Context
+		ReflectionTestUtils.setField(generator, "os", obsService);
+	}
+
+	/**
+	 * A randomly generated numeric value can fall outside the concept's reference range, which the
+	 * core ObsValidator (>= 2.7) rejects with a ValidationException. That must not abort the whole
+	 * demo data generation - the single offending obs is skipped instead.
+	 */
+	@Test
+	public void createObs_shouldSkipObsThatFailsValidationRatherThanPropagate() {
+		when(obsService.saveObs(any(Obs.class), any()))
+				.thenThrow(new ValidationException("valueNumeric: error.value.outOfRange.low"));
+
+		Encounter encounter = new Encounter();
+		Obs partialObs = new Obs();
+		partialObs.setConcept(new Concept(210));
+
+		Obs result = generator.createObs(partialObs, new Patient(), encounter, new Date(), null);
+
+		assertNull("an obs that fails validation should be skipped, not returned", result);
+		assertFalse("the skipped obs must be removed from the encounter so it is not re-saved on flush",
+				encounter.getAllObs(true).contains(partialObs));
+	}
+
+	@Test
+	public void createObs_shouldReturnTheSavedObsWhenValidationPasses() {
+		Obs saved = new Obs();
+		when(obsService.saveObs(any(Obs.class), any())).thenReturn(saved);
+
+		Obs result = generator.createObs(new Obs(), new Patient(), new Encounter(), new Date(), null);
+
+		assertSame(saved, result);
+	}
+}


### PR DESCRIPTION
## Problem

`DemoObsGenerator` generates random numeric obs values and clamps them to the concept's **`ConceptNumeric`** absolute bounds (in `ObsValueGenerator.createObsWithNumericValue`). Since core 2.7, though, the core `ObsValidator` validates numeric obs against the applicable **`ConceptReferenceRange`**, whose absolute bounds can be stricter than — or defined where there is none on — the `ConceptNumeric`.

When a generated value falls outside that reference range, `saveObs` throws:

```
org.openmrs.api.ValidationException: 'obs id is null' failed to validate with reason: valueNumeric: error.value.outOfRange.low
    at org.openmrs.module.referencedemodata.obs.DemoObsGenerator.createObs(DemoObsGenerator.java:...)
    ...
    at org.openmrs.module.referencedemodata.ReferenceDemoDataActivator.started(...)
```

That exception propagates out of `ReferenceDemoDataActivator.started()` and **aborts the entire run**, so every patient after the offending one gets no demo data (in my case **39/50 patients**). Because `Randomizer` uses a fixed seed (`new Random(0)`), the failure is **deterministic** — the same value fails on every run, so restarting/retrying never helps.

### Where it bites (Reference Application 3.7.1 / core 2.8.8)

Two concepts whose `ConceptNumeric` bounds diverge from their reference ranges:

| concept | `ConceptNumeric` | `ConceptReferenceRange` |
|--------|------------------|--------------------------|
| 210 — Alkaline phosphatase | `low_absolute` unset | low `0` → a generated negative value is rejected (`outOfRange.low`) |
| 4184 — Respiratory rate | `hi_absolute` 999 | hi `99` → a high value would be rejected (`outOfRange.high`) |

## Fix

Catch the `ValidationException` when saving a generated obs, log a warning, and **skip that single obs** (removing it from the encounter) so generation continues to completion.

## Why not clamp to the reference range instead?

That's the more complete fix, but `ConceptReferenceRange` only exists on core **≥ 2.7**, while this module compiles against **`openMRSVersion` 2.2.0** — so it can't be referenced here without raising the module's target platform. This change keeps the module resilient on every supported platform; a reference-range-aware clamp could be layered on later behind a version guard.

## Testing

The failing path only manifests on core ≥ 2.7 with `ConceptReferenceRange` data, whereas the module's own context-sensitive test harness runs against 2.2.0, so it can't reproduce the exact validation failure. Verified manually by regenerating the RefApp 3.7.1 demo database end-to-end: before this change generation aborted at 39/50 patients (~3707 obs); with the offending bounds corrected it completed with **all 50 patients (50/50 with encounters), 5348 obs, zero validation errors**, confirming this is the only crash on that path.

## Note on branch

Opened against `2.x` since that's the released 2.6.x line the O3 standalone consumes; the same change applies to `3.x`.